### PR TITLE
Add date formatter config for the contents

### DIFF
--- a/Sources/ToucanSDK/Extensions/Dictionary+Extensions.swift
+++ b/Sources/ToucanSDK/Extensions/Dictionary+Extensions.swift
@@ -124,11 +124,12 @@ extension Dictionary where Key == String, Value == Any {
         value(keyPath, as: Bool.self)
     }
 
-    func date(_ keyPath: String) -> Date? {
+    func date(_ keyPath: String, format: String) -> Date? {
         guard let rawDate = value(keyPath, as: String.self) else {
             return nil
         }
-        let formatter = DateFormatters.contentLoader
+        let formatter = DateFormatters.baseFormatter
+        formatter.dateFormat = format
         return formatter.date(from: rawDate)
     }
 

--- a/Sources/ToucanSDK/Formatters/DateFormatters.swift
+++ b/Sources/ToucanSDK/Formatters/DateFormatters.swift
@@ -16,12 +16,6 @@ struct DateFormatters {
         return formatter
     }
 
-    static var contentLoader: DateFormatter {
-        let formatter = baseFormatter
-        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
-        return formatter
-    }
-
     static var rss: DateFormatter {
         let formatter = baseFormatter
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss Z"

--- a/Sources/ToucanSDK/Source/Config.swift
+++ b/Sources/ToucanSDK/Source/Config.swift
@@ -38,6 +38,7 @@ struct Config {
 
     struct Content {
         let folder: String
+        let dateFormat: String
         let assets: Location
     }
 

--- a/Sources/ToucanSDK/Source/ConfigLoader.swift
+++ b/Sources/ToucanSDK/Source/ConfigLoader.swift
@@ -76,10 +76,12 @@ private extension Config.Types {
 private extension Config.Content {
 
     enum Keys {
+        static let dateFormat = "dateFormat"
         static let assets = "assets"
     }
 
     enum Defaults {
+        static let dateFormat = "yyyy-MM-dd HH:mm:ss"
         static let contentFolder = "content"
         static let assetsFolder = "assets"
     }
@@ -221,6 +223,10 @@ struct ConfigLoader {
             content.string(Config.Location.Keys.folder)
             ?? Config.Content.Defaults.contentFolder
 
+        let contentDateFormat =
+            content.string(Config.Content.Keys.dateFormat)
+            ?? Config.Content.Defaults.dateFormat
+
         let contentAssets = content.dict(Config.Content.Keys.assets)
         let contentAssetsFolder =
             contentAssets
@@ -250,6 +256,7 @@ struct ConfigLoader {
             types: .init(folder: typesFolder),
             content: .init(
                 folder: contentFolder,
+                dateFormat: contentDateFormat,
                 assets: .init(folder: contentAssetsFolder)
             )
         )

--- a/Sources/ToucanSDK/Source/PageBundleLoader.swift
+++ b/Sources/ToucanSDK/Source/PageBundleLoader.swift
@@ -213,14 +213,22 @@ struct PageBundleLoader {
     }
 
     func publication(frontMatter: [String: Any]) -> Date {
-        guard let date = frontMatter.date(Keys.publication.rawValue) else {
+        guard
+            let date = frontMatter.date(
+                Keys.publication.rawValue,
+                format: config.content.dateFormat
+            )
+        else {
             return now
         }
         return date
     }
 
     func expiration(frontMatter: [String: Any]) -> Date? {
-        frontMatter.date(Keys.expiration.rawValue)
+        frontMatter.date(
+            Keys.expiration.rawValue,
+            format: config.content.dateFormat
+        )
     }
 
     func slug(frontMatter: [String: Any], fallback: String) -> String {
@@ -313,6 +321,7 @@ struct PageBundleLoader {
         at location: PageBundleLocation
     ) throws -> PageBundle? {
         let dirUrl = contentUrl.appendingPathComponent(location.path)
+
         guard fileManager.directoryExists(at: dirUrl) else {
             return nil
         }
@@ -338,6 +347,7 @@ struct PageBundleLoader {
             }
             /// filter out unpublished
             let publication = publication(frontMatter: frontMatter)
+
             if publication > now {
                 return nil
             }

--- a/Tests/ToucanSDKTests/SourceTestSuite.swift
+++ b/Tests/ToucanSDKTests/SourceTestSuite.swift
@@ -19,58 +19,58 @@ final class SourceTestSuite: XCTestCase {
             + "/sites/"
     }
 
-//    func loadConfig(
-//        _ site: String
-//    ) async throws {
-//        let baseUrl = URL(fileURLWithPath: sitesPath)
-//        let siteUrl = baseUrl.appendingPathComponent(site)
-//        let srcUrl = siteUrl.appendingPathComponent("src")
-//        
-//        let configLoader = ConfigLoader(
-//            sourceUrl: srcUrl,
-//            fileManager: .default,
-//            baseUrl: nil
-//        )
-//        _ = try configLoader.load()
-//    }
-//
-//    func testLoadConfig() async throws {
-//        for argument in [
-//            "demo"
-//            //            "theswiftdev.com",
-//            //            "binarybirds.com",
-//            //            "swiftonserver.com",
-//        ] {
-//            try await loadConfig(argument)
-//        }
-//
-//    }
-//
-//    func loadContents(
-//        _ site: String
-//    ) async throws {
-//        let baseUrl = URL(fileURLWithPath: sitesPath)
-//        let siteUrl = baseUrl.appendingPathComponent(site)
-//        let srcUrl = siteUrl.appendingPathComponent("src")
-//        let configLoader = ConfigLoader(
-//            sourceUrl: srcUrl,
-//            fileManager: .default,
-//            baseUrl: nil
-//        )
-//        let _ = try configLoader.load()
-//    }
-//
-//    func testLoadContents() async throws {
-//        for argument in [
-//            "demo"
-//            //            "theswiftdev.com",
-//            //            "binarybirds.com",
-//            //            "swiftonserver.com",
-//        ] {
-//            try await loadContents(argument)
-//        }
-//
-//    }
+    //    func loadConfig(
+    //        _ site: String
+    //    ) async throws {
+    //        let baseUrl = URL(fileURLWithPath: sitesPath)
+    //        let siteUrl = baseUrl.appendingPathComponent(site)
+    //        let srcUrl = siteUrl.appendingPathComponent("src")
+    //
+    //        let configLoader = ConfigLoader(
+    //            sourceUrl: srcUrl,
+    //            fileManager: .default,
+    //            baseUrl: nil
+    //        )
+    //        _ = try configLoader.load()
+    //    }
+    //
+    //    func testLoadConfig() async throws {
+    //        for argument in [
+    //            "demo"
+    //            //            "theswiftdev.com",
+    //            //            "binarybirds.com",
+    //            //            "swiftonserver.com",
+    //        ] {
+    //            try await loadConfig(argument)
+    //        }
+    //
+    //    }
+    //
+    //    func loadContents(
+    //        _ site: String
+    //    ) async throws {
+    //        let baseUrl = URL(fileURLWithPath: sitesPath)
+    //        let siteUrl = baseUrl.appendingPathComponent(site)
+    //        let srcUrl = siteUrl.appendingPathComponent("src")
+    //        let configLoader = ConfigLoader(
+    //            sourceUrl: srcUrl,
+    //            fileManager: .default,
+    //            baseUrl: nil
+    //        )
+    //        let _ = try configLoader.load()
+    //    }
+    //
+    //    func testLoadContents() async throws {
+    //        for argument in [
+    //            "demo"
+    //            //            "theswiftdev.com",
+    //            //            "binarybirds.com",
+    //            //            "swiftonserver.com",
+    //        ] {
+    //            try await loadContents(argument)
+    //        }
+    //
+    //    }
 
     //    func testUserDefined() async throws {
     //

--- a/Tests/ToucanSDKTests/ToucanTestSuite.swift
+++ b/Tests/ToucanSDKTests/ToucanTestSuite.swift
@@ -19,31 +19,31 @@ final class ToucanTestSuite: XCTestCase {
             + "/sites/"
     }
 
-//    func generate(
-//        _ site: String
-//    ) async throws {
-//        let baseUrl = URL(fileURLWithPath: sitesPath)
-//        let siteUrl = baseUrl.appendingPathComponent(site)
-//        let srcUrl = siteUrl.appendingPathComponent("src")
-//        let destUrl = siteUrl.appendingPathComponent("dist")
-//
-//        let toucan = Toucan(
-//            input: srcUrl.path,
-//            output: destUrl.path,
-//            baseUrl: nil
-//        )
-//        try toucan.generate()
-//    }
-//
-//    func testGenerate() async throws {
-//        for argument in [
-//            //                "minimal",
-//            "demo"
-//            //            "theswiftdev.com",
-//            //            "binarybirds.com",
-//            //            "swiftonserver.com",
-//        ] {
-//            try await generate(argument)
-//        }
-//    }
+    //    func generate(
+    //        _ site: String
+    //    ) async throws {
+    //        let baseUrl = URL(fileURLWithPath: sitesPath)
+    //        let siteUrl = baseUrl.appendingPathComponent(site)
+    //        let srcUrl = siteUrl.appendingPathComponent("src")
+    //        let destUrl = siteUrl.appendingPathComponent("dist")
+    //
+    //        let toucan = Toucan(
+    //            input: srcUrl.path,
+    //            output: destUrl.path,
+    //            baseUrl: nil
+    //        )
+    //        try toucan.generate()
+    //    }
+    //
+    //    func testGenerate() async throws {
+    //        for argument in [
+    //            //                "minimal",
+    //            "demo"
+    //            //            "theswiftdev.com",
+    //            //            "binarybirds.com",
+    //            //            "swiftonserver.com",
+    //        ] {
+    //            try await generate(argument)
+    //        }
+    //    }
 }


### PR DESCRIPTION
Add a config option to customize the dateformat for all the content types.

```yaml
site:
    baseUrl: "http://localhost:3000/"
    dateFormat: "yyyy-MM-dd" 

content:
    dateFormat: "yyyy-MM-dd"
```

The site date format will be used when rendering dates.
The content date format will be used when loading contents.