### PR TITLE
Fix year variable

### DIFF
--- a/Sources/ToucanSDK/Site/Types/Output+HTML.swift
+++ b/Sources/ToucanSDK/Site/Types/Output+HTML.swift
@@ -44,6 +44,7 @@ struct HTML: Output {
                 "site": site,
                 "page": page,
                 "pagination": pagination,
+                "year": year
             ]
         )
         .sanitized()


### PR DESCRIPTION
- The `{{year}}` variable was missing from the template context.