### PR TITLE
Update install-toucan.sh to create /usr/local/bin directory

### DIFF
--- a/scripts/install-toucan.sh
+++ b/scripts/install-toucan.sh
@@ -5,6 +5,11 @@ log() { printf -- "** %s\n" "$*" >&2; }
 error() { printf -- "** ERROR: %s\n" "$*" >&2; }
 fatal() { error "$@"; exit 1; }
 
+if [ ! -d "/usr/local/bin" ]; then
+    echo "Creating directory /usr/local/bin"
+    mkdir -p "/usr/local/bin"
+    echo "/usr/local/bin directory created"
+fi
 
 swift build -c release
 install .build/release/toucan-cli /usr/local/bin/toucan


### PR DESCRIPTION
For machines that are affected by bug #24, these changes create the `/usr/local/bin` directory.

For this to work on those machines the make command needs to be called with sudo...

`sudo make install`

...this requires the admin password.