### PR TITLE
Fix asset url resolution

### DIFF
--- a/Sources/ToucanSDK/PageBundle/PageBundle.swift
+++ b/Sources/ToucanSDK/PageBundle/PageBundle.swift
@@ -18,6 +18,7 @@ struct PageBundle {
 
     let id: String
     let url: URL
+    let baseUrl: String
 
     let slug: String
     let permalink: String
@@ -48,7 +49,7 @@ struct PageBundle {
             return path
         }
         let src = String(path.dropFirst(prefix.count))
-        return "/" + config.assets.folder + "/" + assetsLocation + "/" + src
+        return baseUrl + config.assets.folder + "/" + assetsLocation + "/" + src
     }
 
     // MARK: -

--- a/Sources/ToucanSDK/PageBundle/PageBundleLoader.swift
+++ b/Sources/ToucanSDK/PageBundle/PageBundleLoader.swift
@@ -163,6 +163,7 @@ public struct PageBundleLoader {
             return .init(
                 id: id,
                 url: dirUrl,
+                baseUrl: sourceConfig.site.baseUrl,
                 slug: slug,
                 permalink: slug.permalink(
                     baseUrl: sourceConfig.site.baseUrl

--- a/Sources/ToucanSDK/Renderers/HTMLRenderer.swift
+++ b/Sources/ToucanSDK/Renderers/HTMLRenderer.swift
@@ -266,6 +266,7 @@ struct HTMLRenderer {
                     let finalBundle = PageBundle(
                         id: pageBundle.id,
                         url: pageBundle.url,
+                        baseUrl: source.sourceConfig.site.baseUrl,
                         slug: finalSlug,
                         permalink: finalSlug.permalink(
                             baseUrl: source.sourceConfig.site.baseUrl

--- a/Tests/ToucanSDKTests/Mocks/PageBundle+Mocks.swift
+++ b/Tests/ToucanSDKTests/Mocks/PageBundle+Mocks.swift
@@ -14,6 +14,7 @@ extension PageBundle {
     static let post1 = PageBundle(
         id: "post-1",
         url: URL(fileURLWithPath: "/"),
+        baseUrl: "http://localhost:3000/",
         slug: "post-1",
         permalink: "post-1",
         title: "Post 1",
@@ -59,6 +60,7 @@ extension PageBundle {
     static let author1 = PageBundle(
         id: "author-1",
         url: URL(fileURLWithPath: "/"),
+        baseUrl: "http://localhost:3000/",
         slug: "author-1",
         permalink: "author-1",
         title: "Author 1",
@@ -101,6 +103,7 @@ extension PageBundle {
     static let page1 = PageBundle(
         id: "page-1",
         url: URL(fileURLWithPath: "/"),
+        baseUrl: "http://localhost:3000/",
         slug: "page-1",
         permalink: "page-1",
         title: "Page 1",


### PR DESCRIPTION
Fixes an issue when base url contains a subpath component:
- add base url as a prefix to assets 
