### PR TITLE
Add config support to change RSS feed output file

### DIFF
--- a/Sources/ToucanSDK/Config/Config.swift
+++ b/Sources/ToucanSDK/Config/Config.swift
@@ -107,11 +107,19 @@ struct Config {
             let template: String
         }
 
+        struct RSS {
+            enum Keys {
+                static let output = "output"
+            }
+            let output: String
+        }
+
         enum Keys {
             static let dateFormat = "dateFormat"
             static let assets = "assets"
             static let home = "home"
             static let notFound = "notFound"
+            static let rss = "rss"
         }
 
         let folder: String
@@ -119,19 +127,22 @@ struct Config {
         let assets: Location
         let home: Page
         let notFound: Page
+        let rss: RSS
 
         init(
             folder: String,
             dateFormat: String,
             assets: Config.Location,
             home: Page,
-            notFound: Page
+            notFound: Page,
+            rss: RSS
         ) {
             self.folder = folder
             self.dateFormat = dateFormat
             self.assets = assets
             self.home = home
             self.notFound = notFound
+            self.rss = rss
         }
 
         init(_ dict: [String: Any]) {
@@ -162,6 +173,12 @@ struct Config {
                     ?? Config.defaults.contents.notFound.id,
                 template: notFound.string(Page.Keys.template)
                     ?? Config.defaults.contents.notFound.template
+            )
+
+            let rss = dict.dict(Keys.rss)
+            self.rss = .init(
+                output: rss.string(RSS.Keys.output)
+                    ?? Config.defaults.contents.rss.output
             )
         }
     }
@@ -288,6 +305,9 @@ extension Config {
             notFound: .init(
                 id: "404",
                 template: "pages.404"
+            ),
+            rss: .init(
+                output: "rss.xml"
             )
         ),
         transformers: .init(

--- a/Sources/ToucanSDK/Renderers/RSSRenderer.swift
+++ b/Sources/ToucanSDK/Renderers/RSSRenderer.swift
@@ -9,11 +9,7 @@ import Foundation
 
 struct RSSRenderer {
 
-    public enum Files {
-        static let rss = "rss.xml"
-    }
-
-    let site: Site
+    let sourceConfig: SourceConfig
     let destinationUrl: URL
     let fileManager: FileManager
     let templateRenderer: MustacheToHTMLRenderer
@@ -42,10 +38,10 @@ struct RSSRenderer {
             ?? rssDateFormatter.string(from: .init())
 
         let context = RSSContext(
-            title: site.title,
-            description: site.description,
-            baseUrl: site.baseUrl,
-            language: site.language,
+            title: sourceConfig.site.title,
+            description: sourceConfig.site.description,
+            baseUrl: sourceConfig.site.baseUrl,
+            language: sourceConfig.site.language,
             lastBuildDate: rssDateFormatter.string(from: .init()),
             publicationDate: publicationDate,
             items: items
@@ -53,7 +49,9 @@ struct RSSRenderer {
         try templateRenderer.render(
             template: "rss",
             with: context,
-            to: destinationUrl.appendingPathComponent(Files.rss)
+            to:
+                destinationUrl
+                .appendingPathComponent(sourceConfig.config.contents.rss.output)
         )
     }
 }

--- a/Sources/ToucanSDK/Toucan.swift
+++ b/Sources/ToucanSDK/Toucan.swift
@@ -152,7 +152,7 @@ public struct Toucan {
             try sitemapRenderer.render()
 
             let rssRenderer = RSSRenderer(
-                site: source.sourceConfig.site,
+                sourceConfig: source.sourceConfig,
                 destinationUrl: workDirUrl,
                 fileManager: .default,
                 templateRenderer: templateRenderer,


### PR DESCRIPTION
Now it's possible to change `rss.xml` output to a custom name via the config:

```yml
contents:
  rss:
    output: feed.xml
```