### PR TITLE
CI for Swift 6.1

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -28,6 +28,7 @@ jobs:
       matrix:
         image:
           - 'swift:6.0'
+          - 'swiftlang/swift:nightly-6.1-jammy'
     container:
       image: ${{ matrix.image }}
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         image:
           - 'swift:6.0'
-          - 'swiftlang/swift:nightly-6.1-jammy'
+          - 'swift:6.1'
     container:
       image: ${{ matrix.image }}
     steps:


### PR DESCRIPTION
Since 6.1 is now released, it's time to add it to the CI pipeline.

Let's see if Toucan works with the 6.1 nightly toolchain, we can update the action file once 6.1 is tagged on DockerHub.