### PR TITLE
Implement content filter rules

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "df533dba1d6ef11f0837aad1608ddbcbf9073922ae85ab9cabc51f4d3dae5373",
+  "originHash" : "a94b8b28e1775d58d6ea51e2529b7117cd4bd90ea6a6971c37be23cd93fc2924",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/hummingbird-project/hummingbird",
       "state" : {
-        "revision" : "567c1fdcd577d3463a1406a34d9a64749bf583ec",
-        "version" : "2.9.0"
+        "revision" : "df95fe30a712803273dbf90572a4c498f7bf3b01",
+        "version" : "2.11.1"
       }
     },
     {
@@ -79,7 +79,7 @@
       "location" : "https://github.com/swiftlang/swift-cmark.git",
       "state" : {
         "branch" : "gfm",
-        "revision" : "b022b08312decdc46585e0b3440d97f6f22ef703"
+        "revision" : "b97d09472e847a416629f026eceae0e2afcfad65"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-http-structured-headers.git",
       "state" : {
-        "revision" : "d01361d32e14ae9b70ea5bd308a3794a198a2706",
-        "version" : "1.2.0"
+        "revision" : "8e769facea6b7d46ea60e5e93635a384fd573480",
+        "version" : "1.2.1"
       }
     },
     {
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-http-types.git",
       "state" : {
-        "revision" : "ef18d829e8b92d731ad27bb81583edd2094d1ce3",
-        "version" : "1.3.1"
+        "revision" : "a0a57e949a8903563aba4615869310c0ebf14c03",
+        "version" : "1.4.0"
       }
     },
     {
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log",
       "state" : {
-        "revision" : "96a2f8a0fa41e9e09af4585e2724c4e825410b91",
-        "version" : "1.6.2"
+        "revision" : "3d8596ed08bd13520157f0355e35caed215ffbfa",
+        "version" : "1.6.3"
       }
     },
     {
@@ -133,7 +133,7 @@
       "location" : "https://github.com/apple/swift-markdown",
       "state" : {
         "branch" : "main",
-        "revision" : "e62a44fd1f2764ba8807db3b6f257627449bbb8c"
+        "revision" : "4e6854f056a5ea80515cbd306e09d4b488889b90"
       }
     },
     {
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-metrics.git",
       "state" : {
-        "revision" : "5e63558d12e0267782019f5dadfcae83a7d06e09",
-        "version" : "2.5.1"
+        "revision" : "44491db7cc66774ab930cf15f36324e16b06f425",
+        "version" : "2.6.1"
       }
     },
     {
@@ -204,8 +204,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-numerics.git",
       "state" : {
-        "revision" : "0a5bc04095a675662cf24757cc0640aa2204253b",
-        "version" : "1.0.2"
+        "revision" : "e0ec0f5f3af6f3e4d5e7a19d2af26b481acb6ba8",
+        "version" : "1.0.3"
       }
     },
     {
@@ -222,8 +222,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
       "state" : {
-        "revision" : "c2e97cf6f81510f2d6b4a69453861db65d478560",
-        "version" : "2.6.3"
+        "revision" : "7ee57f99fbe0073c3700997186721e74d925b59b",
+        "version" : "2.7.0"
       }
     },
     {
@@ -249,8 +249,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/scinfu/SwiftSoup",
       "state" : {
-        "revision" : "6b4930da67b462d3f200472c902dd016d37a554d",
-        "version" : "2.7.7"
+        "revision" : "bba848db50462894e7fc0891d018dfecad4ef11e",
+        "version" : "2.8.7"
       }
     },
     {
@@ -258,8 +258,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jpsim/Yams",
       "state" : {
-        "revision" : "2688707e563b44d7d87c29ba6c5ca04ce86ae58b",
-        "version" : "5.3.0"
+        "revision" : "b4b8042411dc7bbb696300a34a4bf3ba1b7ad19b",
+        "version" : "5.3.1"
       }
     }
   ],

--- a/Sources/ToucanModels/Pipeline/Pipeline+ContentTypes.swift
+++ b/Sources/ToucanModels/Pipeline/Pipeline+ContentTypes.swift
@@ -36,6 +36,15 @@ extension Pipeline {
         /// A list of content types that should be tracked for last update timestamps.
         public var lastUpdate: [String]
 
+        /// A mapping of content type keys to filtering conditions.
+        ///
+        /// Each key represents a content type (e.g., `"post"`, `"author"`), and its value
+        /// defines a condition that must be met for the content to be included in the pipeline.
+        /// This enables fine-grained control over which specific content items are published.
+        ///
+        /// If a content type is not listed in `filterRules`, it is not subject to condition-based filtering.
+        public var filterRules: [String: Condition]
+
         // MARK: - Defaults
 
         /// Default configuration with no filtering or update tracking.
@@ -43,7 +52,8 @@ extension Pipeline {
             .init(
                 include: [],
                 exclude: [],
-                lastUpdate: []
+                lastUpdate: [],
+                filterRules: [:]
             )
         }
 
@@ -55,14 +65,17 @@ extension Pipeline {
         ///   - include: List of explicitly allowed content types.
         ///   - exclude: List of content types to exclude from processing.
         ///   - lastUpdate: List of content types to monitor for timestamp changes.
+        ///   - filterRules: Mapping of content type keys to conditions used to filter content items.
         public init(
             include: [String],
             exclude: [String],
-            lastUpdate: [String]
+            lastUpdate: [String],
+            filterRules: [String: Condition]
         ) {
             self.include = include
             self.exclude = exclude
             self.lastUpdate = lastUpdate
+            self.filterRules = filterRules
         }
 
         // MARK: - Decoding
@@ -88,7 +101,8 @@ extension Pipeline {
             self.init(
                 include: include,
                 exclude: exclude,
-                lastUpdate: lastUpdate
+                lastUpdate: lastUpdate,
+                filterRules: [:]
             )
         }
 

--- a/Sources/ToucanModels/Query/Content+RunQuery.swift
+++ b/Sources/ToucanModels/Query/Content+RunQuery.swift
@@ -18,7 +18,15 @@ public extension [Content] {
         let contents = self.filter {
             query.contentType == $0.definition.id
         }
-        return filter(contents: contents, using: query)
+        let now = Date().timeIntervalSince1970
+        return filter(
+            contents: contents,
+            using: query.resolveFilterParameters(
+                with: [
+                    "date.now": .init(now)
+                ]
+            )
+        )
     }
 
     /// Filters, sorts, and slices the given content array based on a query.

--- a/Sources/ToucanModels/Query/Content+RunQuery.swift
+++ b/Sources/ToucanModels/Query/Content+RunQuery.swift
@@ -12,13 +12,15 @@ public extension [Content] {
     /// Executes a `Query` against the current content collection, applying filtering,
     /// sorting, and pagination.
     ///
-    /// - Parameter query: The `Query` object containing filtering, ordering, and limit logic.
+    /// - Parameters:
+    ///   - query: The `Query` object containing filtering, ordering, and limit logic.
+    ///   - now: The current timestamp used for time-based filtering.
     /// - Returns: A filtered, sorted, and paginated array of `Content` items.
-    func run(query: Query) -> [Content] {
-        let contents = self.filter {
-            query.contentType == $0.definition.id
-        }
-        let now = Date().timeIntervalSince1970
+    func run(
+        query: Query,
+        now: TimeInterval
+    ) -> [Content] {
+        let contents = filter { query.contentType == $0.definition.id }
         return filter(
             contents: contents,
             using: query.resolveFilterParameters(

--- a/Sources/ToucanSource/Bundle/ContentFilter.swift
+++ b/Sources/ToucanSource/Bundle/ContentFilter.swift
@@ -1,0 +1,46 @@
+//
+//  ContentFilter.swift
+//  Toucan
+//
+//  Created by Tibor Bödecs on 2025. 04. 18..
+//
+
+import ToucanModels
+
+/// A utility that filters content based on specified conditions.
+///
+/// `ContentFilter` applies filtering logic to collections of `Content` items,
+/// using a dictionary of conditions keyed by content type identifiers.
+struct ContentFilter {
+
+    /// A dictionary mapping content type identifiers to filtering conditions.
+    let filterRules: [String: Condition]
+
+    /// Applies the filtering rules to the provided content items.
+    ///
+    /// - Parameter contents: The list of `Content` items to filter.
+    /// - Returns: A new list containing only the filtered content items.
+    func applyRules(
+        contents: [Content]
+    ) -> [Content] {
+        let groups = Dictionary(grouping: contents, by: { $0.definition.id })
+
+        var result: [Content] = []
+        for (id, contents) in groups {
+            if let condition = filterRules[id] ?? filterRules["*"] {
+                let items = contents.run(
+                    query: .init(
+                        contentType: id,
+                        filter: condition,
+                    )
+                )
+                result.append(contentsOf: items)
+            }
+            else {
+                result.append(contentsOf: contents)
+            }
+        }
+        return result
+    }
+
+}

--- a/Sources/ToucanSource/Bundle/ContentFilter.swift
+++ b/Sources/ToucanSource/Bundle/ContentFilter.swift
@@ -6,6 +6,7 @@
 //
 
 import ToucanModels
+import Foundation
 
 /// A utility that filters content based on specified conditions.
 ///
@@ -18,10 +19,13 @@ struct ContentFilter {
 
     /// Applies the filtering rules to the provided content items.
     ///
-    /// - Parameter contents: The list of `Content` items to filter.
+    /// - Parameters:
+    ///   - contents: The list of `Content` items to filter.
+    ///   - now: The current timestamp used for time-based filtering.
     /// - Returns: A new list containing only the filtered content items.
     func applyRules(
-        contents: [Content]
+        contents: [Content],
+        now: TimeInterval
     ) -> [Content] {
         let groups = Dictionary(grouping: contents, by: { $0.definition.id })
 
@@ -32,7 +36,8 @@ struct ContentFilter {
                     query: .init(
                         contentType: id,
                         filter: condition,
-                    )
+                    ),
+                    now: now
                 )
                 result.append(contentsOf: items)
             }

--- a/Sources/ToucanSource/Bundle/ContentIteratorResolver.swift
+++ b/Sources/ToucanSource/Bundle/ContentIteratorResolver.swift
@@ -19,6 +19,7 @@ import Logging
 struct ContentIteratorResolver {
 
     var baseUrl: String
+    var now: TimeInterval
 
     func resolve(
         contents: [Content],
@@ -43,7 +44,7 @@ struct ContentIteratorResolver {
                     orderBy: query.orderBy
                 )
 
-                let total = contents.run(query: countQuery).count
+                let total = contents.run(query: countQuery, now: now).count
                 let limit = max(1, query.limit ?? 10)
                 let numberOfPages = (total + limit - 1) / limit
 
@@ -102,7 +103,8 @@ struct ContentIteratorResolver {
                             offset: offset,
                             filter: query.filter,
                             orderBy: query.orderBy
-                        )
+                        ),
+                        now: now
                     )
 
                     alteredContent.iteratorInfo = .init(

--- a/Sources/ToucanSource/Bundle/SourceBundleRenderer.swift
+++ b/Sources/ToucanSource/Bundle/SourceBundleRenderer.swift
@@ -126,8 +126,16 @@ public struct SourceBundleRenderer {
                 with: pipelineFormatters
             )
 
+            let filter = ContentFilter(
+                filterRules: pipeline.contentTypes.filterRules
+            )
+
+            let filteredContents = filter.applyRules(
+                contents: sourceBundle.contents
+            )
+
             let contents = iteratorResolver.resolve(
-                contents: sourceBundle.contents,
+                contents: filteredContents,
                 using: pipeline
             )
 

--- a/Sources/ToucanSource/Bundle/SourceBundleRenderer.swift
+++ b/Sources/ToucanSource/Bundle/SourceBundleRenderer.swift
@@ -73,7 +73,8 @@ public struct SourceBundleRenderer {
     /// Returns the last content update based on the pipeline config
     private func getLastContentUpdate(
         contents: [Content],
-        pipeline: Pipeline
+        pipeline: Pipeline,
+        now: TimeInterval
     ) -> TimeInterval? {
         var updateTypes = contents.map(\.definition.id)
         if !pipeline.contentTypes.lastUpdate.isEmpty {
@@ -94,7 +95,8 @@ public struct SourceBundleRenderer {
                                 direction: .desc
                             )
                         ]
-                    )
+                    ),
+                    now: now
                 )
                 return items.first?.rawValue.lastModificationDate
             }
@@ -113,7 +115,8 @@ public struct SourceBundleRenderer {
         var siteContext = getSiteContext(for: now)
         var results: [PipelineResult] = []
         let iteratorResolver = ContentIteratorResolver(
-            baseUrl: sourceBundle.settings.baseUrl
+            baseUrl: sourceBundle.settings.baseUrl,
+            now: now
         )
 
         for pipeline in sourceBundle.pipelines {
@@ -131,7 +134,8 @@ public struct SourceBundleRenderer {
             )
 
             let filteredContents = filter.applyRules(
-                contents: sourceBundle.contents
+                contents: sourceBundle.contents,
+                now: now
             )
 
             let contents = iteratorResolver.resolve(
@@ -142,7 +146,8 @@ public struct SourceBundleRenderer {
             let lastUpdate =
                 getLastContentUpdate(
                     contents: contents,
-                    pipeline: pipeline
+                    pipeline: pipeline,
+                    now: now
                 ) ?? now
 
             let lastUpdateContext = lastUpdate.toDateFormats(
@@ -155,7 +160,8 @@ public struct SourceBundleRenderer {
                 context: [
                     "site": .init(siteContext)
                 ],
-                pipeline: pipeline
+                pipeline: pipeline,
+                now: now
             )
 
             switch pipeline.engine.id {
@@ -181,7 +187,8 @@ public struct SourceBundleRenderer {
     mutating func getContextBundles(
         contents: [Content],
         context globalContext: [String: AnyCodable],
-        pipeline: Pipeline
+        pipeline: Pipeline,
+        now: TimeInterval
     ) throws -> [ContextBundle] {
         contents.compactMap { content in
             let isAllowed = pipeline.contentTypes.isAllowed(
@@ -194,7 +201,8 @@ public struct SourceBundleRenderer {
             let pipelineContext = getPipelineContext(
                 contents: contents,
                 pipeline: pipeline,
-                currentSlug: content.slug.value
+                currentSlug: content.slug.value,
+                now: now
             )
             .recursivelyMerged(with: globalContext)
 
@@ -202,7 +210,8 @@ public struct SourceBundleRenderer {
                 contents: contents,
                 content: content,
                 pipeline: pipeline,
-                pipelineContext: pipelineContext
+                pipelineContext: pipelineContext,
+                now: now
             )
         }
     }
@@ -210,11 +219,12 @@ public struct SourceBundleRenderer {
     mutating func getPipelineContext(
         contents: [Content],
         pipeline: Pipeline,
-        currentSlug: String
+        currentSlug: String,
+        now: TimeInterval
     ) -> [String: AnyCodable] {
         var rawContext: [String: AnyCodable] = [:]
         for (key, query) in pipeline.queries {
-            let results = contents.run(query: query)
+            let results = contents.run(query: query, now: now)
 
             rawContext[key] = .init(
                 results.map {
@@ -222,6 +232,7 @@ public struct SourceBundleRenderer {
                         contents: contents,
                         for: $0,
                         pipeline: pipeline,
+                        now: now,
                         scopeKey: query.scope ?? "list",
                         currentSlug: currentSlug
                     )
@@ -236,7 +247,8 @@ public struct SourceBundleRenderer {
     mutating func getIteratorContext(
         contents: [Content],
         content: Content,
-        pipeline: Pipeline
+        pipeline: Pipeline,
+        now: TimeInterval
     ) -> [String: AnyCodable] {
         guard let iteratorInfo = content.iteratorInfo else {
             return [:]
@@ -246,6 +258,7 @@ public struct SourceBundleRenderer {
                 contents: contents,
                 for: $0,
                 pipeline: pipeline,
+                now: now,
                 scopeKey: iteratorInfo.scope ?? "list",
                 currentSlug: content.slug.value
             )
@@ -267,13 +280,15 @@ public struct SourceBundleRenderer {
         contents: [Content],
         content: Content,
         pipeline: Pipeline,
-        pipelineContext: [String: AnyCodable]
+        pipelineContext: [String: AnyCodable],
+        now: TimeInterval
     ) -> ContextBundle {
 
         let pageContext = getContentContext(
             contents: contents,
             for: content,
             pipeline: pipeline,
+            now: now,
             scopeKey: "detail",
             currentSlug: content.slug.value
         )
@@ -281,7 +296,8 @@ public struct SourceBundleRenderer {
         let iteratorContext = getIteratorContext(
             contents: contents,
             content: content,
-            pipeline: pipeline
+            pipeline: pipeline,
+            now: now
         )
 
         let context: [String: AnyCodable] = [
@@ -314,6 +330,7 @@ public struct SourceBundleRenderer {
         contents: [Content],
         for content: Content,
         pipeline: Pipeline,
+        now: TimeInterval,
         scopeKey: String,
         currentSlug: String?,
         allowSubQueries: Bool = true  // allow top level queries only,
@@ -434,7 +451,8 @@ public struct SourceBundleRenderer {
                             )
                         ),
                         orderBy: orderBy
-                    )
+                    ),
+                    now: now
                 )
                 result[key] = .init(
                     relationContents.map {
@@ -442,6 +460,7 @@ public struct SourceBundleRenderer {
                             contents: contents,
                             for: $0,
                             pipeline: pipeline,
+                            now: now,
                             scopeKey: "reference",
                             currentSlug: currentSlug,
                             allowSubQueries: false
@@ -457,7 +476,8 @@ public struct SourceBundleRenderer {
                 let queryContents = contents.run(
                     query: query.resolveFilterParameters(
                         with: content.queryFields
-                    )
+                    ),
+                    now: now
                 )
 
                 result[key] = .init(
@@ -466,6 +486,7 @@ public struct SourceBundleRenderer {
                             contents: contents,
                             for: $0,
                             pipeline: pipeline,
+                            now: now,
                             scopeKey: query.scope ?? "list",
                             currentSlug: currentSlug,
                             allowSubQueries: false

--- a/Sources/ToucanTesting/Pipelines/Pipeline+Context.swift
+++ b/Sources/ToucanTesting/Pipelines/Pipeline+Context.swift
@@ -50,11 +50,7 @@ public extension Pipeline.Mocks {
                     ]
                 )
             ),
-            contentTypes: .init(
-                include: [],
-                exclude: [],
-                lastUpdate: []
-            ),
+            contentTypes: .defaults,
             iterators: [
                 "post.pagination": .init(
                     contentType: "post",

--- a/Sources/ToucanTesting/Pipelines/Pipeline+HTML.swift
+++ b/Sources/ToucanTesting/Pipelines/Pipeline+HTML.swift
@@ -37,7 +37,8 @@ public extension Pipeline.Mocks {
                     "rss",
                     "sitemap",
                 ],
-                lastUpdate: []
+                lastUpdate: [],
+                filterRules: [:]
             ),
             // are iterators always pages? iteratorPages? or segments? 🤔
             iterators: [

--- a/Sources/ToucanTesting/Pipelines/Pipeline+RSS.swift
+++ b/Sources/ToucanTesting/Pipelines/Pipeline+RSS.swift
@@ -24,7 +24,8 @@ public extension Pipeline.Mocks {
                     "post",
                     "author",
                     "tag",
-                ]
+                ],
+                filterRules: [:]
             ),
             iterators: [:],
             transformers: [:],

--- a/Sources/ToucanTesting/Pipelines/Pipeline+Redirect.swift
+++ b/Sources/ToucanTesting/Pipelines/Pipeline+Redirect.swift
@@ -20,7 +20,8 @@ public extension Pipeline.Mocks {
                     "redirect"
                 ],
                 exclude: [],
-                lastUpdate: []
+                lastUpdate: [],
+                filterRules: [:]
             ),
             iterators: [:],
             transformers: [:],

--- a/Sources/ToucanTesting/Pipelines/Pipeline+Sitemap.swift
+++ b/Sources/ToucanTesting/Pipelines/Pipeline+Sitemap.swift
@@ -52,7 +52,8 @@ public extension Pipeline.Mocks {
                     "sitemap"
                 ],
                 exclude: [],
-                lastUpdate: []
+                lastUpdate: [],
+                filterRules: [:]
             ),
             iterators: [
                 "post.pagination": .init(

--- a/Tests/ToucanSourceTests/ContentFilterTestSuite.swift
+++ b/Tests/ToucanSourceTests/ContentFilterTestSuite.swift
@@ -1,0 +1,180 @@
+//
+//  ContentFilterTestSuite.swift
+//  Toucan
+//
+//  Created by Tibor Bödecs on 2025. 04. 18..
+//
+
+import Foundation
+import Testing
+import ToucanModels
+import ToucanContent
+import ToucanTesting
+import Logging
+@testable import ToucanSource
+
+@Suite
+struct ContentFilterTestSuite {
+
+    @Test()
+    func genericFilterRules() async throws {
+        let sourceBundle = SourceBundle.Mocks.complete()
+        let posts = sourceBundle.contents
+
+        let filter = ContentFilter(
+            filterRules: [
+                "*": .or(
+                    [
+                        .field(
+                            key: "title",
+                            operator: .like,
+                            value: "10"
+                        ),
+                        .field(
+                            key: "name",
+                            operator: .like,
+                            value: "10"
+                        ),
+                    ]
+                )
+            ]
+        )
+
+        let res = filter.applyRules(contents: posts)
+
+        let expGroups = Dictionary(
+            grouping: sourceBundle.contents,
+            by: { $0.definition.id }
+        )
+
+        let resGroups = Dictionary(
+            grouping: res,
+            by: { $0.definition.id }
+        )
+
+        for key in expGroups.keys {
+
+            let exp1 =
+                expGroups[key]?
+                .filter {
+                    $0.properties["title"]?.stringValue()?.hasSuffix("10")
+                        ?? $0.properties["name"]?.stringValue()?.hasSuffix("10")
+                        ?? false
+                } ?? []
+
+            let res1 =
+                resGroups[key]?
+                .filter {
+                    $0.properties["title"]?.stringValue()?.hasSuffix("10")
+                        ?? $0.properties["name"]?.stringValue()?.hasSuffix("10")
+                        ?? false
+                } ?? []
+
+            #expect(res1.count == exp1.count)
+            for i in 0..<res1.count {
+                #expect(res1[i].slug == exp1[i].slug)
+            }
+        }
+    }
+
+    @Test()
+    func specificFilterRules() async throws {
+        let sourceBundle = SourceBundle.Mocks.complete()
+        let posts = sourceBundle.contents
+
+        let filter = ContentFilter(
+            filterRules: [
+                "*": .or(
+                    [
+                        .field(
+                            key: "title",
+                            operator: .like,
+                            value: "10"
+                        ),
+                        .field(
+                            key: "name",
+                            operator: .like,
+                            value: "10"
+                        ),
+                    ]
+                ),
+                "post": .field(
+                    key: "featured",
+                    operator: .equals,
+                    value: true
+                ),
+            ]
+        )
+
+        let res = filter.applyRules(contents: posts)
+
+        let expGroups = Dictionary(
+            grouping: sourceBundle.contents,
+            by: { $0.definition.id }
+        )
+
+        let resGroups = Dictionary(
+            grouping: res,
+            by: { $0.definition.id }
+        )
+
+        for key in expGroups.keys {
+
+            let exp1 =
+                expGroups[key]?
+                .filter {
+                    if key == "post" {
+                        return $0.properties["featured"]?.boolValue() ?? false
+                    }
+                    return $0.properties["title"]?.stringValue()?
+                        .hasSuffix("10") ?? $0.properties["name"]?
+                        .stringValue()?
+                        .hasSuffix("10") ?? false
+                } ?? []
+
+            let res1 =
+                resGroups[key]?
+                .filter {
+                    if key == "post" {
+                        return $0.properties["featured"]?.boolValue() ?? false
+                    }
+                    return $0.properties["title"]?.stringValue()?
+                        .hasSuffix("10") ?? $0.properties["name"]?
+                        .stringValue()?
+                        .hasSuffix("10") ?? false
+                } ?? []
+
+            #expect(res1.count == exp1.count)
+            for i in 0..<res1.count {
+                #expect(res1[i].slug == exp1[i].slug)
+            }
+        }
+    }
+
+    @Test()
+    func noFilterRules() async throws {
+        let sourceBundle = SourceBundle.Mocks.complete()
+        let posts = sourceBundle.contents
+
+        let filter = ContentFilter(
+            filterRules: [:]
+        )
+
+        let res = filter.applyRules(contents: posts)
+
+        let expGroups = Dictionary(
+            grouping: sourceBundle.contents,
+            by: { $0.definition.id }
+        )
+
+        let resGroups = Dictionary(
+            grouping: res,
+            by: { $0.definition.id }
+        )
+
+        for key in expGroups.keys {
+            #expect(expGroups[key]?.count == resGroups[key]?.count)
+        }
+    }
+
+}

--- a/Tests/ToucanSourceTests/ContentFilterTestSuite.swift
+++ b/Tests/ToucanSourceTests/ContentFilterTestSuite.swift
@@ -40,7 +40,8 @@ struct ContentFilterTestSuite {
             ]
         )
 
-        let res = filter.applyRules(contents: posts)
+        let now = Date().timeIntervalSince1970
+        let res = filter.applyRules(contents: posts, now: now)
 
         let expGroups = Dictionary(
             grouping: sourceBundle.contents,
@@ -105,8 +106,8 @@ struct ContentFilterTestSuite {
                 ),
             ]
         )
-
-        let res = filter.applyRules(contents: posts)
+        let now = Date().timeIntervalSince1970
+        let res = filter.applyRules(contents: posts, now: now)
 
         let expGroups = Dictionary(
             grouping: sourceBundle.contents,
@@ -160,7 +161,8 @@ struct ContentFilterTestSuite {
             filterRules: [:]
         )
 
-        let res = filter.applyRules(contents: posts)
+        let now = Date().timeIntervalSince1970
+        let res = filter.applyRules(contents: posts, now: now)
 
         let expGroups = Dictionary(
             grouping: sourceBundle.contents,
@@ -267,7 +269,11 @@ struct ContentFilterTestSuite {
         )
 
         let posts = [post1, post2]
-        let res = filter.applyRules(contents: posts)
+
+        let res = filter.applyRules(
+            contents: posts,
+            now: now.timeIntervalSince1970
+        )
         #expect(res.count == 1)
         #expect(res[0].slug.value == "test1")
     }
@@ -342,7 +348,10 @@ struct ContentFilterTestSuite {
         )
 
         let posts = [post1, post2]
-        let res = filter.applyRules(contents: posts)
+        let res = filter.applyRules(
+            contents: posts,
+            now: now.timeIntervalSince1970
+        )
         #expect(res.count == 1)
         #expect(res[0].slug.value == "test1")
     }

--- a/Tests/ToucanSourceTests/QueryTestSuite.swift
+++ b/Tests/ToucanSourceTests/QueryTestSuite.swift
@@ -22,7 +22,8 @@ struct QueryTestSuite {
             offset: 1
         )
 
-        let results = sourceBundle.contents.run(query: query)
+        let now = Date().timeIntervalSince1970
+        let results = sourceBundle.contents.run(query: query, now: now)
         try #require(results.count == 1)
         #expect(
             results[0].properties["name"]?.value(as: String.self) == "Author #2"
@@ -39,7 +40,8 @@ struct QueryTestSuite {
             offset: 3
         )
 
-        let results = sourceBundle.contents.run(query: query)
+        let now = Date().timeIntervalSince1970
+        let results = sourceBundle.contents.run(query: query, now: now)
         try #require(results.count == 2)
         #expect(
             results[0].properties["name"]?.value(as: String.self) == "Author #4"
@@ -59,7 +61,8 @@ struct QueryTestSuite {
             )
         )
 
-        let results = sourceBundle.contents.run(query: query)
+        let now = Date().timeIntervalSince1970
+        let results = sourceBundle.contents.run(query: query, now: now)
         try #require(results.count == 1)
         #expect(
             results[0].properties["name"]?.value(as: String.self) == "Author #6"
@@ -79,7 +82,8 @@ struct QueryTestSuite {
             )
         )
 
-        let results = sourceBundle.contents.run(query: query)
+        let now = Date().timeIntervalSince1970
+        let results = sourceBundle.contents.run(query: query, now: now)
         try #require(results.count == 1)
         #expect(
             results[0].properties["name"]?.value(as: String.self) == "Author #2"
@@ -99,7 +103,8 @@ struct QueryTestSuite {
             )
         )
 
-        let results = sourceBundle.contents.run(query: query)
+        let now = Date().timeIntervalSince1970
+        let results = sourceBundle.contents.run(query: query, now: now)
         try #require(results.count == 1)
         #expect(
             results[0].properties["name"]?.value(as: String.self) == "Author #3"
@@ -119,7 +124,8 @@ struct QueryTestSuite {
             )
         )
 
-        let results = sourceBundle.contents.run(query: query)
+        let now = Date().timeIntervalSince1970
+        let results = sourceBundle.contents.run(query: query, now: now)
         try #require(results.count == 0)
     }
 
@@ -136,7 +142,8 @@ struct QueryTestSuite {
             )
         )
 
-        let results = sourceBundle.contents.run(query: query)
+        let now = Date().timeIntervalSince1970
+        let results = sourceBundle.contents.run(query: query, now: now)
         try #require(results.count == 9)
         #expect(
             results[0].properties["name"]?.value(as: String.self) == "Author #2"
@@ -156,7 +163,8 @@ struct QueryTestSuite {
             )
         )
 
-        let results = sourceBundle.contents.run(query: query)
+        let now = Date().timeIntervalSince1970
+        let results = sourceBundle.contents.run(query: query, now: now)
         try #require(results.count == 2)
         #expect(
             results[0].properties["title"]?.value(as: String.self)
@@ -181,7 +189,8 @@ struct QueryTestSuite {
             )
         )
 
-        let results = sourceBundle.contents.run(query: query)
+        let now = Date().timeIntervalSince1970
+        let results = sourceBundle.contents.run(query: query, now: now)
         try #require(results.count == 3)
         #expect(
             results[0].properties["title"]?.value(as: String.self)
@@ -210,7 +219,8 @@ struct QueryTestSuite {
             )
         )
 
-        let results = sourceBundle.contents.run(query: query)
+        let now = Date().timeIntervalSince1970
+        let results = sourceBundle.contents.run(query: query, now: now)
         try #require(results.count == 2)
         #expect(
             results[0].properties["name"]?.value(as: String.self)
@@ -235,7 +245,8 @@ struct QueryTestSuite {
             )
         )
 
-        let results = sourceBundle.contents.run(query: query)
+        let now = Date().timeIntervalSince1970
+        let results = sourceBundle.contents.run(query: query, now: now)
         try #require(results.count == 3)
         #expect(
             results[0].properties["name"]?.value(as: String.self)
@@ -260,7 +271,8 @@ struct QueryTestSuite {
             )
         )
 
-        let results = sourceBundle.contents.run(query: query)
+        let now = Date().timeIntervalSince1970
+        let results = sourceBundle.contents.run(query: query, now: now)
         try #require(results.count == 2)
         #expect(
             results[0].properties["title"]?.value(as: String.self)
@@ -285,7 +297,8 @@ struct QueryTestSuite {
             )
         )
 
-        let results = sourceBundle.contents.run(query: query)
+        let now = Date().timeIntervalSince1970
+        let results = sourceBundle.contents.run(query: query, now: now)
         try #require(results.count == 3)
         #expect(
             results[0].properties["title"]?.value(as: String.self)
@@ -314,7 +327,8 @@ struct QueryTestSuite {
             )
         )
 
-        let results = sourceBundle.contents.run(query: query)
+        let now = Date().timeIntervalSince1970
+        let results = sourceBundle.contents.run(query: query, now: now)
         try #require(results.count == 2)
         #expect(
             results[0].properties["name"]?.value(as: String.self)
@@ -339,7 +353,8 @@ struct QueryTestSuite {
             )
         )
 
-        let results = sourceBundle.contents.run(query: query)
+        let now = Date().timeIntervalSince1970
+        let results = sourceBundle.contents.run(query: query, now: now)
         try #require(results.count == 3)
         #expect(
             results[0].properties["name"]?.value(as: String.self)
@@ -364,7 +379,8 @@ struct QueryTestSuite {
             )
         )
 
-        let results = sourceBundle.contents.run(query: query)
+        let now = Date().timeIntervalSince1970
+        let results = sourceBundle.contents.run(query: query, now: now)
         #expect(results.count == 0)
     }
 
@@ -391,7 +407,8 @@ struct QueryTestSuite {
             ]
         )
 
-        let results = sourceBundle.contents.run(query: query)
+        let now = Date().timeIntervalSince1970
+        let results = sourceBundle.contents.run(query: query, now: now)
         try #require(results.count == 2)
         #expect(
             results[0].properties["name"]?.value(as: String.self) == "Author #6"
@@ -424,7 +441,8 @@ struct QueryTestSuite {
             ]
         )
 
-        let results = sourceBundle.contents.run(query: query)
+        let now = Date().timeIntervalSince1970
+        let results = sourceBundle.contents.run(query: query, now: now)
         #expect(results.isEmpty)
     }
 
@@ -451,7 +469,8 @@ struct QueryTestSuite {
             ]
         )
 
-        let results = sourceBundle.contents.run(query: query)
+        let now = Date().timeIntervalSince1970
+        let results = sourceBundle.contents.run(query: query, now: now)
         try #require(results.count == 1)
         #expect(
             results[0].properties["name"]?.value(as: String.self) == "Author #6"
@@ -474,7 +493,8 @@ struct QueryTestSuite {
             ]
         )
 
-        let results = sourceBundle.contents.run(query: query)
+        let now = Date().timeIntervalSince1970
+        let results = sourceBundle.contents.run(query: query, now: now)
         try #require(results.count == 2)
         #expect(
             results[0].properties["name"]?.value(as: String.self) == "Author #4"
@@ -500,7 +520,8 @@ struct QueryTestSuite {
             ]
         )
 
-        let results = sourceBundle.contents.run(query: query)
+        let now = Date().timeIntervalSince1970
+        let results = sourceBundle.contents.run(query: query, now: now)
         try #require(results.count == 2)
         #expect(
             results[0].properties["name"]?.value(as: String.self) == "Author #1"
@@ -526,7 +547,8 @@ struct QueryTestSuite {
             ]
         )
 
-        let results = sourceBundle.contents.run(query: query)
+        let now = Date().timeIntervalSince1970
+        let results = sourceBundle.contents.run(query: query, now: now)
         try #require(results.count == 2)
         #expect(
             results[0].properties["name"]?.value(as: String.self) == "Author #1"
@@ -549,7 +571,8 @@ struct QueryTestSuite {
             )
         )
 
-        let results = sourceBundle.contents.run(query: query)
+        let now = Date().timeIntervalSince1970
+        let results = sourceBundle.contents.run(query: query, now: now)
         try #require(results.count == 2)
         #expect(
             results[0].properties["name"]?.value(as: String.self) == "Author #1"
@@ -573,7 +596,8 @@ struct QueryTestSuite {
             )
         )
 
-        let results = sourceBundle.contents.run(query: query)
+        let now = Date().timeIntervalSince1970
+        let results = sourceBundle.contents.run(query: query, now: now)
         try #require(results.count == 0)
     }
 
@@ -590,7 +614,8 @@ struct QueryTestSuite {
             )
         )
 
-        let results = sourceBundle.contents.run(query: query)
+        let now = Date().timeIntervalSince1970
+        let results = sourceBundle.contents.run(query: query, now: now)
         try #require(results.count == 2)
         #expect(
             results[0].properties["name"]?.value(as: String.self) == "Author #1"
@@ -614,7 +639,8 @@ struct QueryTestSuite {
             )
         )
 
-        let results = sourceBundle.contents.run(query: query)
+        let now = Date().timeIntervalSince1970
+        let results = sourceBundle.contents.run(query: query, now: now)
         try #require(results.count == 0)
     }
 
@@ -631,7 +657,8 @@ struct QueryTestSuite {
             )
         )
 
-        let results = sourceBundle.contents.run(query: query)
+        let now = Date().timeIntervalSince1970
+        let results = sourceBundle.contents.run(query: query, now: now)
         try #require(results.count == 8)
     }
 
@@ -648,7 +675,8 @@ struct QueryTestSuite {
             )
         )
 
-        let results = sourceBundle.contents.run(query: query)
+        let now = Date().timeIntervalSince1970
+        let results = sourceBundle.contents.run(query: query, now: now)
         try #require(results.count == 10)
     }
 
@@ -665,7 +693,8 @@ struct QueryTestSuite {
             )
         )
 
-        let results = sourceBundle.contents.run(query: query)
+        let now = Date().timeIntervalSince1970
+        let results = sourceBundle.contents.run(query: query, now: now)
         try #require(results.count == 10)
     }
 
@@ -682,7 +711,8 @@ struct QueryTestSuite {
             )
         )
 
-        let results = sourceBundle.contents.run(query: query)
+        let now = Date().timeIntervalSince1970
+        let results = sourceBundle.contents.run(query: query, now: now)
         try #require(results.count == 0)
     }
 
@@ -699,7 +729,8 @@ struct QueryTestSuite {
             )
         )
 
-        let results = sourceBundle.contents.run(query: query)
+        let now = Date().timeIntervalSince1970
+        let results = sourceBundle.contents.run(query: query, now: now)
         try #require(results.count == 8)
     }
 
@@ -716,7 +747,8 @@ struct QueryTestSuite {
             )
         )
 
-        let results = sourceBundle.contents.run(query: query)
+        let now = Date().timeIntervalSince1970
+        let results = sourceBundle.contents.run(query: query, now: now)
         try #require(results.count == 10)
     }
 
@@ -733,7 +765,8 @@ struct QueryTestSuite {
             )
         )
 
-        let results = sourceBundle.contents.run(query: query)
+        let now = Date().timeIntervalSince1970
+        let results = sourceBundle.contents.run(query: query, now: now)
         try #require(results.count == 10)
     }
 
@@ -750,7 +783,8 @@ struct QueryTestSuite {
             )
         )
 
-        let results = sourceBundle.contents.run(query: query)
+        let now = Date().timeIntervalSince1970
+        let results = sourceBundle.contents.run(query: query, now: now)
         try #require(results.count == 0)
     }
 
@@ -775,7 +809,10 @@ struct QueryTestSuite {
                 )
             ]
         )
-        let results1 = sourceBundle.contents.run(query: query1)
+        let results1 = sourceBundle.contents.run(
+            query: query1,
+            now: now.timeIntervalSince1970
+        )
         try #require(results1.count == 5)
 
         let query = Query(
@@ -794,7 +831,10 @@ struct QueryTestSuite {
             ]
         )
 
-        let results = sourceBundle.contents.run(query: query)
+        let results = sourceBundle.contents.run(
+            query: query,
+            now: now.timeIntervalSince1970
+        )
         try #require(results.count == 1)
         #expect(
             results[0].properties["title"]?.value(as: String.self) == "Post #6"
@@ -828,7 +868,8 @@ struct QueryTestSuite {
                 )
             ]
         )
-        let results1 = sourceBundle.contents.run(query: query1)
+        let now = Date().timeIntervalSince1970
+        let results1 = sourceBundle.contents.run(query: query1, now: now)
         try #require(results1.count == 1)
     }
 
@@ -855,7 +896,8 @@ struct QueryTestSuite {
                 "id": "category-1"
             ]
         )
-        let results1 = sourceBundle.contents.run(query: query1)
+        let now = Date().timeIntervalSince1970
+        let results1 = sourceBundle.contents.run(query: query1, now: now)
         try #require(results1.count == 1)
     }
 
@@ -871,15 +913,16 @@ struct QueryTestSuite {
                 value: true
             )
         )
-
+        let now = Date().timeIntervalSince1970
         let resolver = ContentIteratorResolver(
-            baseUrl: "http://localhost:3000"
+            baseUrl: "http://localhost:3000",
+            now: now
         )
         let contents = resolver.resolve(
             contents: sourceBundle.contents,
             using: Pipeline.Mocks.html()
         )
-        let results = contents.run(query: query)
+        let results = contents.run(query: query, now: now)
         try #require(results.count == 5)
     }
 

--- a/Tests/ToucanSourceTests/SourceBundle/SourceBundleContextTestSuite.swift
+++ b/Tests/ToucanSourceTests/SourceBundle/SourceBundleContextTestSuite.swift
@@ -42,11 +42,7 @@ struct SourceBundleContextTestSuite {
                     )
                 ],
                 dataTypes: .defaults,
-                contentTypes: .init(
-                    include: [],
-                    exclude: [],
-                    lastUpdate: []
-                ),
+                contentTypes: .defaults,
                 iterators: [:],
                 transformers: [:],
                 engine: .init(
@@ -207,11 +203,7 @@ struct SourceBundleContextTestSuite {
                 scopes: [:],
                 queries: [:],
                 dataTypes: .defaults,
-                contentTypes: .init(
-                    include: [],
-                    exclude: [],
-                    lastUpdate: []
-                ),
+                contentTypes: .defaults,
                 iterators: [:],
                 transformers: [:],
                 engine: .init(

--- a/Tests/ToucanSourceTests/SourceBundle/SourceBundleErrorTests.swift
+++ b/Tests/ToucanSourceTests/SourceBundle/SourceBundleErrorTests.swift
@@ -36,11 +36,7 @@ struct SourceBundleErrorTests {
                 scopes: [:],
                 queries: [:],
                 dataTypes: .defaults,
-                contentTypes: .init(
-                    include: [],
-                    exclude: [],
-                    lastUpdate: []
-                ),
+                contentTypes: .defaults,
                 iterators: [:],
                 transformers: [:],
                 engine: .init(

--- a/Tests/ToucanSourceTests/SourceBundle/SourceBundlePageLinkTestSuite.swift
+++ b/Tests/ToucanSourceTests/SourceBundle/SourceBundlePageLinkTestSuite.swift
@@ -47,11 +47,7 @@ struct SourceBundlePageLinkTestSuite {
                     )
                 ],
                 dataTypes: .defaults,
-                contentTypes: .init(
-                    include: [],
-                    exclude: [],
-                    lastUpdate: []
-                ),
+                contentTypes: .defaults,
                 iterators: [
                     "post.pagination": Query(
                         contentType: "post",

--- a/Tests/ToucanSourceTests/SourceBundle/SourceBundleScopeTestSuite.swift
+++ b/Tests/ToucanSourceTests/SourceBundle/SourceBundleScopeTestSuite.swift
@@ -155,6 +155,9 @@ struct SourceBundleScopeTestSuite {
             logger: logger
         )
         let results = try renderer.render(now: now)
+            .sorted {
+                $0.destination.path < $1.destination.path
+            }
 
         #expect(results.count == 2)
 
@@ -208,7 +211,6 @@ struct SourceBundleScopeTestSuite {
 
         let data1 = try #require(results[1].contents.data(using: .utf8))
         let exp1 = try decoder.decode(Exp1.self, from: data1)
-
         #expect(exp1.context.featured.allSatisfy { $0.isCurrentURL == nil })
     }
 }

--- a/Tests/ToucanSourceTests/SourceBundle/SourceBundleScopeTestSuite.swift
+++ b/Tests/ToucanSourceTests/SourceBundle/SourceBundleScopeTestSuite.swift
@@ -68,11 +68,7 @@ struct SourceBundleScopeTestSuite {
                     )
                 ],
                 dataTypes: .defaults,
-                contentTypes: .init(
-                    include: [],
-                    exclude: [],
-                    lastUpdate: []
-                ),
+                contentTypes: .defaults,
                 iterators: [:],
                 transformers: [:],
                 engine: .init(


### PR DESCRIPTION
- implement content filter rules
- implement global {{date.now}} query parameter

Example using an updated pipeline configuration:

```yaml
contentTypes: 
    include:
        - page
        - post
    filterRules:
        "*": 
            key: draft
            operator: equals
            value: false
        post:
            and:
            - key: draft
              operator: equals
              value: false
            - key: publication
              operator: lessThanOrEquals
              value: "{{date.now}}"
            - key: expiration
              operator: greaterThanOrEquals
              value: "{{date.now}}"
```