### PR TITLE
Feature/asset behaviors

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c3f52043964d62dfe94070ffaf7f482940a7ae9a9535262ae0033cccdd34f78d",
+  "originHash" : "3b9fee41609bd163ed1473094c39f0a6baf304c0e85366ab303e85043c60aee7",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -35,6 +35,24 @@
       "state" : {
         "revision" : "df95fe30a712803273dbf90572a4c498f7bf3b01",
         "version" : "2.11.1"
+      }
+    },
+    {
+      "identity" : "semver.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/johnfairh/Semver.swift.git",
+      "state" : {
+        "revision" : "0a6e2fe061ecb840c9bf80b6427e70ac039239fa",
+        "version" : "1.2.4"
+      }
+    },
+    {
+      "identity" : "sourcemapper",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/johnfairh/SourceMapper.git",
+      "state" : {
+        "revision" : "2c86d8f44beb2c41effa2f9c5f6cf29b871bf3b9",
+        "version" : "2.0.0"
       }
     },
     {
@@ -89,6 +107,15 @@
       "state" : {
         "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
         "version" : "1.1.4"
+      }
+    },
+    {
+      "identity" : "swift-css-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/stackotter/swift-css-parser",
+      "state" : {
+        "revision" : "6cf16c6696def00a313daef0e29eb27f5c39ece4",
+        "version" : "0.1.2"
       }
     },
     {
@@ -206,6 +233,24 @@
       "state" : {
         "revision" : "e0ec0f5f3af6f3e4d5e7a19d2af26b481acb6ba8",
         "version" : "1.0.3"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "d72aed98f8253ec1aa9ea1141e28150f408cf17f",
+        "version" : "1.29.0"
+      }
+    },
+    {
+      "identity" : "swift-sass",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/johnfairh/swift-sass.git",
+      "state" : {
+        "revision" : "e2c9c4e18c08f0b31f9ddbd3677a7a37460ad132",
+        "version" : "3.1.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -40,8 +40,9 @@ let package = Package(
         .package(url: "https://github.com/scinfu/SwiftSoup", from: "2.7.0"),
         .package(url: "https://github.com/aus-der-Technik/FileMonitor", from: "1.2.0"),
         .package(url: "https://github.com/Zollerboy1/SwiftCommand", from: "1.4.0"),
-//        .package(url: "https://github.com/johnfairh/swift-sass", from: "3.1.0")
-//        .package(url: "https://github.com/swiftlang/swift-subprocess", branch: "main")
+        .package(url: "https://github.com/johnfairh/swift-sass", from: "3.1.0"),
+        .package(url: "https://github.com/stackotter/swift-css-parser", from: "0.1.2"),
+//        .package(url: "https://github.com/swiftlang/swift-subprocess", branch: "main"),
     ],
     targets: [
         // MARK: - executable targets
@@ -107,7 +108,6 @@ let package = Package(
                 .product(name: "Mustache", package: "swift-mustache"),
                 .product(name: "SwiftSoup", package: "SwiftSoup"),
                 .product(name: "Yams", package: "yams"),
-                //.product(name: "DartSass", package: "swift-sass"),
                 .target(name: "ToucanFileSystem"),
                 .target(name: "ToucanSource"),
                 .target(name: "ToucanTesting"),
@@ -137,6 +137,8 @@ let package = Package(
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "Mustache", package: "swift-mustache"),
                 .product(name: "FileManagerKit", package: "file-manager-kit"),
+                .product(name: "DartSass", package: "swift-sass"),
+                .product(name: "SwiftCSSParser", package: "swift-css-parser"),
                 .target(name: "ToucanModels"),
                 .target(name: "ToucanContent"),
                 .target(name: "ToucanInfo"),

--- a/Sources/ToucanModels/Pipeline/Pipeline+Assets.swift
+++ b/Sources/ToucanModels/Pipeline/Pipeline+Assets.swift
@@ -50,6 +50,12 @@ extension Pipeline {
         ///   - output: The destination location for the processed asset.
         public struct Behavior: Decodable {
 
+            private enum CodingKeys: CodingKey {
+                case id
+                case input
+                case output
+            }
+
             /// The unique identifier for the behavior.
             public var id: String
             /// The input location for the behavior.
@@ -71,6 +77,41 @@ extension Pipeline {
                 self.id = id
                 self.input = input
                 self.output = output
+            }
+
+            /// Decodes a `Behavior` instance from a configuration source (e.g., JSON/YAML).
+            ///
+            /// Missing fields default
+            public init(from decoder: any Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+
+                let id = try container.decode(String.self, forKey: .id)
+
+                let input =
+                    try container.decodeIfPresent(
+                        Location.self,
+                        forKey: .input
+                    )
+                    ?? .init(
+                        name: "*",
+                        ext: "*"
+                    )
+
+                let output =
+                    try container.decodeIfPresent(
+                        Location.self,
+                        forKey: .output
+                    )
+                    ?? .init(
+                        name: "*",
+                        ext: "*"
+                    )
+
+                self.init(
+                    id: id,
+                    input: input,
+                    output: output
+                )
             }
         }
 

--- a/Sources/ToucanModels/Pipeline/Pipeline+Assets.swift
+++ b/Sources/ToucanModels/Pipeline/Pipeline+Assets.swift
@@ -50,10 +50,19 @@ extension Pipeline {
         ///   - output: The destination location for the processed asset.
         public struct Behavior: Decodable {
 
+            /// The unique identifier for the behavior.
             public var id: String
+            /// The input location for the behavior.
             public var input: Location
+            /// The output location for the behavior.
             public var output: Location
 
+            /// Initializes a behavior
+            ///
+            /// - Properties:
+            ///   - id: A unique identifier for the behavior.
+            ///   - input: The source location of the asset.
+            ///   - output: The destination location for the processed asset.
             public init(
                 id: String,
                 input: Location,
@@ -130,7 +139,9 @@ extension Pipeline {
 
         /// Initializes an `Assets` instance with a given set of properties.
         ///
-        /// - Parameter properties: The array of asset properties to include.
+        /// - Parameters:
+        ///   - behaviors: The array of asset behaviors.
+        ///   - properties: The array of asset properties to include.
         public init(
             behaviors: [Behavior],
             properties: [Property]

--- a/Sources/ToucanSDK/Toucan.swift
+++ b/Sources/ToucanSDK/Toucan.swift
@@ -147,29 +147,29 @@ public struct Toucan {
 
             // MARK: - Copy default assets
 
-            let assetsWriter = AssetsWriter(
-                fileManager: fileManager,
-                sourceConfig: sourceBundle.sourceConfig,
-                workDirUrl: workDirUrl
-            )
-            try assetsWriter.copyDefaultAssets()
+//            let assetsWriter = AssetsWriter(
+//                fileManager: fileManager,
+//                sourceConfig: sourceBundle.sourceConfig,
+//                workDirUrl: workDirUrl
+//            )
+//            try assetsWriter.copyDefaultAssets()
 
-            // MARK: - Copy content assets
-
-            let assetsPath = sourceBundle.config.contents.assets.path
-            let assetsFolder = workDirUrl.appending(path: assetsPath)
-            try fileManager.createDirectory(at: assetsFolder)
-            let scrDirectory = sourceBundle.sourceConfig.contentsUrl
-
-            let contentAssetsWriter = ContentAssetsWriter(
-                fileManager: fileManager,
-                assetsPath: assetsPath,
-                assetsFolder: assetsFolder,
-                scrDirectory: scrDirectory
-            )
-            for content in sourceBundle.contents {
-                try contentAssetsWriter.copyContentAssets(content: content)
-            }
+//            // MARK: - Copy content assets
+//
+//            let assetsPath = sourceBundle.config.contents.assets.path
+//            let assetsFolder = workDirUrl.appending(path: assetsPath)
+//            try fileManager.createDirectory(at: assetsFolder)
+//            let scrDirectory = sourceBundle.sourceConfig.contentsUrl
+//
+//            let contentAssetsWriter = ContentAssetsWriter(
+//                fileManager: fileManager,
+//                assetsPath: assetsPath,
+//                assetsFolder: assetsFolder,
+//                scrDirectory: scrDirectory
+//            )
+//            for content in sourceBundle.contents {
+//                try contentAssetsWriter.copyContentAssets(content: content)
+//            }
 
             // MARK: - Writing results
 

--- a/Sources/ToucanSDK/Toucan.swift
+++ b/Sources/ToucanSDK/Toucan.swift
@@ -147,29 +147,12 @@ public struct Toucan {
 
             // MARK: - Copy default assets
 
-//            let assetsWriter = AssetsWriter(
-//                fileManager: fileManager,
-//                sourceConfig: sourceBundle.sourceConfig,
-//                workDirUrl: workDirUrl
-//            )
-//            try assetsWriter.copyDefaultAssets()
-
-//            // MARK: - Copy content assets
-//
-//            let assetsPath = sourceBundle.config.contents.assets.path
-//            let assetsFolder = workDirUrl.appending(path: assetsPath)
-//            try fileManager.createDirectory(at: assetsFolder)
-//            let scrDirectory = sourceBundle.sourceConfig.contentsUrl
-//
-//            let contentAssetsWriter = ContentAssetsWriter(
-//                fileManager: fileManager,
-//                assetsPath: assetsPath,
-//                assetsFolder: assetsFolder,
-//                scrDirectory: scrDirectory
-//            )
-//            for content in sourceBundle.contents {
-//                try contentAssetsWriter.copyContentAssets(content: content)
-//            }
+            let assetsWriter = AssetsWriter(
+                fileManager: fileManager,
+                sourceConfig: sourceBundle.sourceConfig,
+                workDirUrl: workDirUrl
+            )
+            try assetsWriter.copyDefaultAssets()
 
             // MARK: - Writing results
 
@@ -184,11 +167,16 @@ public struct Toucan {
                     .appending(path: result.destination.file)
                     .appendingPathExtension(result.destination.ext)
 
-                try result.contents.write(
-                    to: outputUrl,
-                    atomically: true,
-                    encoding: .utf8
-                )
+                switch result.source {
+                case .asset(let string):
+                    print("TODO: copy asset")
+                case .content(let string):
+                    try string.write(
+                        to: outputUrl,
+                        atomically: true,
+                        encoding: .utf8
+                    )
+                }
             }
 
             // MARK: - Finalize and cleanup

--- a/Sources/ToucanSDK/Toucan.swift
+++ b/Sources/ToucanSDK/Toucan.swift
@@ -168,20 +168,11 @@ public struct Toucan {
                     .appendingPathExtension(result.destination.ext)
 
                 switch result.source {
-                case .asset(let path, let contents):
-                    if let contents {
-                        try contents.write(
-                            to: outputUrl,
-                            atomically: true,
-                            encoding: .utf8
-                        )
-                    }
-                    else {
-                        let srcUrl = sourceBundle.sourceConfig.contentsUrl
-                            .appending(path: path)
-                        try fileManager.copy(from: srcUrl, to: outputUrl)
-                    }
-                case .content(let string):
+                case .assetFile(let path):
+                    let srcUrl = sourceBundle.sourceConfig.contentsUrl
+                        .appending(path: path)
+                    try fileManager.copy(from: srcUrl, to: outputUrl)
+                case .asset(let string), .content(let string):
                     try string.write(
                         to: outputUrl,
                         atomically: true,

--- a/Sources/ToucanSDK/Toucan.swift
+++ b/Sources/ToucanSDK/Toucan.swift
@@ -168,8 +168,10 @@ public struct Toucan {
                     .appendingPathExtension(result.destination.ext)
 
                 switch result.source {
-                case .asset(let string):
-                    print("TODO: copy asset")
+                case .asset(let path):
+                    let srcUrl = sourceBundle.sourceConfig.contentsUrl
+                        .appending(path: path)
+                    try fileManager.copy(from: srcUrl, to: outputUrl)
                 case .content(let string):
                     try string.write(
                         to: outputUrl,

--- a/Sources/ToucanSDK/Toucan.swift
+++ b/Sources/ToucanSDK/Toucan.swift
@@ -168,10 +168,19 @@ public struct Toucan {
                     .appendingPathExtension(result.destination.ext)
 
                 switch result.source {
-                case .asset(let path):
-                    let srcUrl = sourceBundle.sourceConfig.contentsUrl
-                        .appending(path: path)
-                    try fileManager.copy(from: srcUrl, to: outputUrl)
+                case .asset(let path, let contents):
+                    if let contents {
+                        try contents.write(
+                            to: outputUrl,
+                            atomically: true,
+                            encoding: .utf8
+                        )
+                    }
+                    else {
+                        let srcUrl = sourceBundle.sourceConfig.contentsUrl
+                            .appending(path: path)
+                        try fileManager.copy(from: srcUrl, to: outputUrl)
+                    }
                 case .content(let string):
                     try string.write(
                         to: outputUrl,

--- a/Sources/ToucanSource/Behaviors/CompileSASSBehavior.swift
+++ b/Sources/ToucanSource/Behaviors/CompileSASSBehavior.swift
@@ -41,7 +41,7 @@ struct CompileSASSBehavior {
                     )
             }
             catch {
-                fatalError("\(error)")
+                fatalError("\(error) - \(fileUrl.path())")
             }
 
             semaphore.signal()

--- a/Sources/ToucanSource/Behaviors/CompileSASSBehavior.swift
+++ b/Sources/ToucanSource/Behaviors/CompileSASSBehavior.swift
@@ -1,0 +1,53 @@
+//
+//  CompileSASSBehavior.swift
+//  Toucan
+//
+//  Created by Tibor Bödecs on 2025. 05. 12..
+//
+
+import Foundation
+import DartSass
+
+struct CompileSASSBehavior {
+
+    var compiler: Compiler
+
+    init() throws {
+        self.compiler = try .init()
+    }
+
+    func compile(fileUrl: URL) throws -> String {
+
+        let css = unsafeSyncCompile(fileUrl: fileUrl)
+
+        return css
+    }
+
+    /// NOTE: This is horrible... but we can live with it for a while :)
+    private func unsafeSyncCompile(fileUrl: URL) -> String {
+
+        final class Enclosure: @unchecked Sendable {
+            var value: CompilerResults!
+        }
+
+        let semaphore = DispatchSemaphore(value: 0)
+        let enclosure = Enclosure()
+
+        Task {
+            do {
+                enclosure.value =
+                    try await compiler.compile(
+                        fileURL: fileUrl
+                    )
+            }
+            catch {
+                fatalError("\(error)")
+            }
+
+            semaphore.signal()
+        }
+
+        semaphore.wait()
+        return enclosure.value.css
+    }
+}

--- a/Sources/ToucanSource/Behaviors/MinifyCSSBehavior.swift
+++ b/Sources/ToucanSource/Behaviors/MinifyCSSBehavior.swift
@@ -1,0 +1,21 @@
+//
+//  MinifyCSSBehavior.swift
+//  Toucan
+//
+//  Created by Tibor Bödecs on 2025. 05. 12..
+//
+
+import Foundation
+import SwiftCSSParser
+
+struct MinifyCSSBehavior {
+
+    func minify(fileUrl: URL) throws -> String {
+        let src = try String(
+            contentsOf: fileUrl
+        )
+        let stylesheet = try Stylesheet.parse(from: src)
+        return stylesheet.minified()
+    }
+
+}

--- a/Sources/ToucanSource/Bundle/AssetBehaviorExecutor.swift
+++ b/Sources/ToucanSource/Bundle/AssetBehaviorExecutor.swift
@@ -1,0 +1,179 @@
+//
+//  AssetBehaviorExecutor.swift
+//  Toucan
+//
+//  Created by Tibor Bödecs on 2025. 05. 12..
+//
+
+import Foundation
+import ToucanModels
+
+struct AssetBehaviorExecutor {
+
+    var sourceBundle: SourceBundle
+
+    private func getNameAndExtension(
+        from path: String
+    ) -> (name: String, ext: String) {
+
+        let safePath = path.split(separator: "/").last.map(String.init) ?? ""
+
+        let parts = safePath.split(
+            separator: ".",
+            omittingEmptySubsequences: false
+        )
+        guard parts.count >= 2 else {
+            return (String(safePath), "")  // No extension
+        }
+
+        let ext = String(parts.last!)
+        let filename = parts.dropLast().joined(separator: ".")
+
+        return (filename, ext)
+    }
+
+    private func filterFilePaths(
+        from paths: [String],
+        input: Pipeline.Assets.Location
+    ) -> [String] {
+        paths.filter { filePath in
+            guard let url = URL(string: filePath) else {
+                return false
+            }
+
+            let path = url.deletingLastPathComponent().path
+            let name = url.deletingPathExtension().lastPathComponent
+            let ext = url.pathExtension
+
+            let inputPath = input.path ?? ""
+            let pathMatches =
+                inputPath == "*" || inputPath.isEmpty
+                || path == inputPath
+            let nameMatches =
+                input.name == "*" || input.name.isEmpty
+                || name == input.name
+            let extMatches =
+                input.ext == "*" || input.ext.isEmpty
+                || ext == input.ext
+            return pathMatches && nameMatches && extMatches
+        }
+    }
+
+    func execute(
+        pipeline: Pipeline,
+        contents: [Content]
+    ) throws -> [PipelineResult] {
+        var results: [PipelineResult] = []
+
+        let assetsPath = sourceBundle.config.contents.assets.path
+
+        for content in contents {
+            var assetsReady: Set<String> = .init()
+
+            for behavior in pipeline.assets.behaviors {
+                let isAllowed = pipeline.contentTypes.isAllowed(
+                    contentType: content.definition.id
+                )
+                guard isAllowed else {
+                    continue
+                }
+                let remainingAssets = Set(content.rawValue.assets)
+                    .subtracting(assetsReady)
+
+                let matchingRemainingAssets = filterFilePaths(
+                    from: Array(remainingAssets),
+                    input: behavior.input
+                )
+
+                guard !matchingRemainingAssets.isEmpty else {
+                    continue
+                }
+
+                for inputAsset in matchingRemainingAssets {
+                    let basePath = content.rawValue.origin.path
+                        .split(separator: "/")
+                        .dropLast()
+                        .joined(separator: "/")
+
+                    let sourcePath = [
+                        basePath,
+                        assetsPath,
+                        inputAsset,
+                    ]
+                    .joined(separator: "/")
+
+                    let file = getNameAndExtension(from: inputAsset)
+
+                    let destPath = [
+                        assetsPath,
+                        content.slug.resolveForPath(),
+                        inputAsset,
+                    ]
+                    .joined(separator: "/")
+                    .split(separator: "/")
+                    .dropLast()
+                    .joined(separator: "/")
+
+                    switch behavior.id {
+                    case "compile-sass":
+                        let fileUrl = sourceBundle.sourceConfig.contentsUrl
+                            .appending(
+                                path: sourcePath
+                            )
+
+                        let script = try CompileSASSBehavior()
+                        let css = try script.compile(fileUrl: fileUrl)
+
+                        // TODO: proper output management later on
+                        results.append(
+                            .init(
+                                source: .asset(css),
+                                destination: .init(
+                                    path: destPath,
+                                    file: behavior.output.name,
+                                    ext: behavior.output.ext
+                                )
+                            )
+                        )
+
+                    case "minify-css":
+                        let fileUrl = sourceBundle.sourceConfig.contentsUrl
+                            .appending(
+                                path: sourcePath
+                            )
+
+                        let script = MinifyCSSBehavior()
+                        let css = try script.minify(fileUrl: fileUrl)
+
+                        results.append(
+                            .init(
+                                source: .asset(css),
+                                destination: .init(
+                                    path: destPath,
+                                    file: behavior.output.name,
+                                    ext: behavior.output.ext
+                                )
+                            )
+                        )
+
+                    default:  // copy
+                        results.append(
+                            .init(
+                                source: .assetFile(sourcePath),
+                                destination: .init(
+                                    path: destPath,
+                                    file: file.name,
+                                    ext: file.ext
+                                )
+                            )
+                        )
+                    }
+
+                    assetsReady.insert(inputAsset)
+                }
+            }
+        }
+
+        return results
+    }
+}

--- a/Sources/ToucanSource/Bundle/AssetPipelineResolver.swift
+++ b/Sources/ToucanSource/Bundle/AssetPipelineResolver.swift
@@ -25,9 +25,6 @@ struct AssetPipelineResolver {
         self.assetsPath = assetsPath
         self.baseUrl = baseUrl
         self.config = config
-        self.config.properties.append(
-            contentsOf: Pipeline.Assets.getDefaultProperties()
-        )
     }
 
     func resolve(
@@ -163,7 +160,7 @@ struct AssetPipelineResolver {
 
     private func filterFilePaths(
         from paths: [String],
-        input: Pipeline.Assets.Property.Input
+        input: Pipeline.Assets.Location
     ) -> [String] {
         paths.filter { filePath in
             guard let url = URL(string: filePath) else {

--- a/Sources/ToucanSource/Bundle/AssetPipelineResolver.swift
+++ b/Sources/ToucanSource/Bundle/AssetPipelineResolver.swift
@@ -15,18 +15,6 @@ struct AssetPipelineResolver {
     var baseUrl: String
     var config: Pipeline.Assets
 
-    init(
-        contentsUrl: URL,
-        assetsPath: String,
-        baseUrl: String,
-        config: Pipeline.Assets
-    ) {
-        self.contentsUrl = contentsUrl
-        self.assetsPath = assetsPath
-        self.baseUrl = baseUrl
-        self.config = config
-    }
-
     func resolve(
         _ contents: [Content]
     ) throws -> [Content] {

--- a/Sources/ToucanSource/Bundle/AssetPropertyResolver.swift
+++ b/Sources/ToucanSource/Bundle/AssetPropertyResolver.swift
@@ -1,5 +1,5 @@
 //
-//  AssetPipelineResolver.swift
+//  AssetPropertyResolver.swift
 //  Toucan
 //
 //  Created by Tibor Bödecs on 2025. 04. 19..
@@ -8,7 +8,7 @@
 import Foundation
 import ToucanModels
 
-struct AssetPipelineResolver {
+struct AssetPropertyResolver {
 
     var contentsUrl: URL
     var assetsPath: String

--- a/Sources/ToucanSource/Bundle/ContextBundleToHTMLRenderer.swift
+++ b/Sources/ToucanSource/Bundle/ContextBundleToHTMLRenderer.swift
@@ -75,6 +75,9 @@ struct ContextBundleToHTMLRenderer {
             return nil
         }
 
-        return .init(contents: html, destination: contextBundle.destination)
+        return .init(
+            source: .content(html),
+            destination: contextBundle.destination
+        )
     }
 }

--- a/Sources/ToucanSource/Bundle/ContextBundleToJSONRenderer.swift
+++ b/Sources/ToucanSource/Bundle/ContextBundleToJSONRenderer.swift
@@ -85,7 +85,7 @@ struct ContextBundleToJSONRenderer {
             return nil
         }
         return .init(
-            contents: json,
+            source: .content(json),
             destination: contextBundle.destination
         )
     }

--- a/Sources/ToucanSource/Bundle/SourceBundleRenderer.swift
+++ b/Sources/ToucanSource/Bundle/SourceBundleRenderer.swift
@@ -110,9 +110,14 @@ public struct SourceBundleRenderer {
         from path: String
     ) -> (name: String, ext: String) {
 
-        let parts = path.split(separator: ".", omittingEmptySubsequences: false)
+        let safePath = path.split(separator: "/").last.map(String.init) ?? ""
+
+        let parts = safePath.split(
+            separator: ".",
+            omittingEmptySubsequences: false
+        )
         guard parts.count >= 2 else {
-            return (String(path), "")  // No extension
+            return (String(safePath), "")  // No extension
         }
 
         let ext = String(parts.last!)
@@ -231,7 +236,10 @@ public struct SourceBundleRenderer {
                     }
 
                     for inputAsset in inputAssets {
-                        let basePath = content.slug.resolveForPath()
+                        let basePath = content.rawValue.origin.path
+                            .split(separator: "/")
+                            .dropLast()
+                            .joined(separator: "/")
 
                         let sourcePath = [
                             basePath,
@@ -245,7 +253,11 @@ public struct SourceBundleRenderer {
                         let destPath = [
                             assetsPath,
                             basePath,
+                            inputAsset,
                         ]
+                        .joined(separator: "/")
+                        .split(separator: "/")
+                        .dropLast()
                         .joined(separator: "/")
 
                         switch behavior.id {

--- a/Sources/ToucanSource/Bundle/SourceBundleRenderer.swift
+++ b/Sources/ToucanSource/Bundle/SourceBundleRenderer.swift
@@ -303,7 +303,7 @@ public struct SourceBundleRenderer {
                             // TODO: proper output management
                             results.append(
                                 .init(
-                                    source: .asset(sourcePath, css),
+                                    source: .asset(css),
                                     destination: .init(
                                         path: destPath,
                                         file: behavior.output.name,
@@ -326,7 +326,6 @@ public struct SourceBundleRenderer {
                             results.append(
                                 .init(
                                     source: .asset(
-                                        sourcePath,
                                         stylesheet.minified()
                                     ),
                                     destination: .init(
@@ -341,7 +340,7 @@ public struct SourceBundleRenderer {
                             // source, destination -> copy recursively
                             results.append(
                                 .init(
-                                    source: .asset(sourcePath, nil),
+                                    source: .assetFile(sourcePath),
                                     destination: .init(
                                         path: destPath,
                                         file: file.name,

--- a/Sources/ToucanSource/Bundle/SourceBundleRenderer.swift
+++ b/Sources/ToucanSource/Bundle/SourceBundleRenderer.swift
@@ -252,7 +252,7 @@ public struct SourceBundleRenderer {
 
                         let destPath = [
                             assetsPath,
-                            basePath,
+                            content.slug.resolveForPath(),
                             inputAsset,
                         ]
                         .joined(separator: "/")

--- a/Sources/ToucanSource/Bundle/SourceBundleRenderer.swift
+++ b/Sources/ToucanSource/Bundle/SourceBundleRenderer.swift
@@ -105,26 +105,6 @@ public struct SourceBundleRenderer {
             .sorted(by: >).first
     }
 
-    private func getNameAndExtension(
-        from path: String
-    ) -> (name: String, ext: String) {
-
-        let safePath = path.split(separator: "/").last.map(String.init) ?? ""
-
-        let parts = safePath.split(
-            separator: ".",
-            omittingEmptySubsequences: false
-        )
-        guard parts.count >= 2 else {
-            return (String(safePath), "")  // No extension
-        }
-
-        let ext = String(parts.last!)
-        let filename = parts.dropLast().joined(separator: ".")
-
-        return (filename, ext)
-    }
-
     /// Starts rendering the source bundle based on current time and pipeline configuration.
     ///
     /// - Parameter now: Current date, used for generation timestamps.
@@ -140,6 +120,8 @@ public struct SourceBundleRenderer {
             baseUrl: sourceBundle.settings.baseUrl,
             now: now
         )
+
+        let executor = AssetBehaviorExecutor(sourceBundle: sourceBundle)
 
         for pipeline in sourceBundle.pipelines {
 
@@ -165,141 +147,11 @@ public struct SourceBundleRenderer {
                 using: pipeline
             )
 
-            func filterFilePaths(
-                from paths: [String],
-                input: Pipeline.Assets.Location
-            ) -> [String] {
-                paths.filter { filePath in
-                    guard let url = URL(string: filePath) else {
-                        return false
-                    }
-
-                    let path = url.deletingLastPathComponent().path
-                    let name = url.deletingPathExtension().lastPathComponent
-                    let ext = url.pathExtension
-
-                    let inputPath = input.path ?? ""
-                    let pathMatches =
-                        inputPath == "*" || inputPath.isEmpty
-                        || path == inputPath
-                    let nameMatches =
-                        input.name == "*" || input.name.isEmpty
-                        || name == input.name
-                    let extMatches =
-                        input.ext == "*" || input.ext.isEmpty
-                        || ext == input.ext
-                    return pathMatches && nameMatches && extMatches
-                }
-            }
-
-            let assetsPath = sourceBundle.config.contents.assets.path
-
-            for content in contents {
-                var assetsReady: Set<String> = .init()
-
-                for behavior in pipeline.assets.behaviors {
-                    let isAllowed = pipeline.contentTypes.isAllowed(
-                        contentType: content.definition.id
-                    )
-                    guard isAllowed else {
-                        continue
-                    }
-                    let remainingAssets = Set(content.rawValue.assets)
-                        .subtracting(assetsReady)
-
-                    let matchingRemainingAssets = filterFilePaths(
-                        from: Array(remainingAssets),
-                        input: behavior.input
-                    )
-
-                    guard !matchingRemainingAssets.isEmpty else {
-                        continue
-                    }
-
-                    for inputAsset in matchingRemainingAssets {
-                        let basePath = content.rawValue.origin.path
-                            .split(separator: "/")
-                            .dropLast()
-                            .joined(separator: "/")
-
-                        let sourcePath = [
-                            basePath,
-                            assetsPath,
-                            inputAsset,
-                        ]
-                        .joined(separator: "/")
-
-                        let file = getNameAndExtension(from: inputAsset)
-
-                        let destPath = [
-                            assetsPath,
-                            content.slug.resolveForPath(),
-                            inputAsset,
-                        ]
-                        .joined(separator: "/")
-                        .split(separator: "/")
-                        .dropLast()
-                        .joined(separator: "/")
-
-                        switch behavior.id {
-                        case "compile-sass":
-                            let fileUrl = sourceBundle.sourceConfig.contentsUrl
-                                .appending(
-                                    path: sourcePath
-                                )
-
-                            let script = try CompileSASSBehavior()
-                            let css = try script.compile(fileUrl: fileUrl)
-
-                            // TODO: proper output management later on
-                            results.append(
-                                .init(
-                                    source: .asset(css),
-                                    destination: .init(
-                                        path: destPath,
-                                        file: behavior.output.name,
-                                        ext: behavior.output.ext
-                                    )
-                                )
-                            )
-
-                        case "minify-css":
-                            let fileUrl = sourceBundle.sourceConfig.contentsUrl
-                                .appending(
-                                    path: sourcePath
-                                )
-
-                            let script = MinifyCSSBehavior()
-                            let css = try script.minify(fileUrl: fileUrl)
-
-                            results.append(
-                                .init(
-                                    source: .asset(css),
-                                    destination: .init(
-                                        path: destPath,
-                                        file: behavior.output.name,
-                                        ext: behavior.output.ext
-                                    )
-                                )
-                            )
-
-                        default:  // copy
-                            results.append(
-                                .init(
-                                    source: .assetFile(sourcePath),
-                                    destination: .init(
-                                        path: destPath,
-                                        file: file.name,
-                                        ext: file.ext
-                                    )
-                                )
-                            )
-                        }
-
-                        assetsReady.insert(inputAsset)
-                    }
-                }
-            }
+            let assetResults = try executor.execute(
+                pipeline: pipeline,
+                contents: contents
+            )
+            results.append(contentsOf: assetResults)
 
             let assetPropertyResolver = AssetPropertyResolver(
                 contentsUrl: sourceBundle.sourceConfig.contentsUrl,

--- a/Sources/ToucanSource/Bundle/SourceBundleRenderer.swift
+++ b/Sources/ToucanSource/Bundle/SourceBundleRenderer.swift
@@ -11,8 +11,6 @@ import ToucanContent
 import FileManagerKit
 import Logging
 import ToucanInfo
-import Dispatch
-import SwiftCSSParser
 
 /// Responsible for rendering the entire site bundle based on the `SourceBundle` configuration.
 ///

--- a/Sources/ToucanSource/Models/Destination.swift
+++ b/Sources/ToucanSource/Models/Destination.swift
@@ -6,7 +6,7 @@
 //
 
 /// Represents the destination location and filename for rendered or transformed content.
-public struct Destination {
+public struct Destination: Sendable {
 
     /// The relative or absolute path to the target directory where the file should be placed.
     public var path: String

--- a/Sources/ToucanSource/Models/PipelineResult.swift
+++ b/Sources/ToucanSource/Models/PipelineResult.swift
@@ -11,8 +11,8 @@ public struct PipelineResult: Sendable {
 
     /// The source material for the pipeline result.
     public enum Source: Sendable {
-        /// The original source material
-        case asset(String)
+        /// The original source material, source path and optional Contents
+        case asset(String, String?)
         /// The final transformed content (e.g., HTML, Markdown, etc.).
         case content(String)
     }
@@ -42,7 +42,7 @@ public struct PipelineResult: Sendable {
         switch source {
         case .content(_):
             return true
-        case .asset(_):
+        case .asset(_, _):
             return false
         }
     }

--- a/Sources/ToucanSource/Models/PipelineResult.swift
+++ b/Sources/ToucanSource/Models/PipelineResult.swift
@@ -35,4 +35,21 @@ public struct PipelineResult: Sendable {
         self.source = source
         self.destination = destination
     }
+
+    /// A Boolean value indicating whether the pipeline result's source is content-based.
+    /// Returns `true` if the source is `.content`, otherwise `false`.
+    public var isContent: Bool {
+        switch source {
+        case .content(_):
+            return true
+        case .asset(_):
+            return false
+        }
+    }
+
+    /// A Boolean value indicating whether the pipeline result's source is an asset.
+    /// Returns `true` if the source is `.asset`, otherwise `false`.
+    public var isAsset: Bool {
+        !isContent
+    }
 }

--- a/Sources/ToucanSource/Models/PipelineResult.swift
+++ b/Sources/ToucanSource/Models/PipelineResult.swift
@@ -7,10 +7,18 @@
 
 /// Represents the output of a content transformation pipeline, including the
 /// transformed content and its intended destination.
-public struct PipelineResult {
+public struct PipelineResult: Sendable {
 
-    /// The final transformed content (e.g., HTML, Markdown, etc.).
-    public var contents: String
+    /// The source material for the pipeline result.
+    public enum Source: Sendable {
+        /// The original source material
+        case asset(String)
+        /// The final transformed content (e.g., HTML, Markdown, etc.).
+        case content(String)
+    }
+
+    /// The source material.
+    public var source: Source
 
     /// The destination metadata describing where or how the content should be output.
     public var destination: Destination
@@ -18,13 +26,13 @@ public struct PipelineResult {
     /// Initializes a new `PipelineResult` with transformed content and a destination.
     ///
     /// - Parameters:
-    ///   - contents: The transformed content string.
+    ///   - source: The source material.
     ///   - destination: A `Destination` indicating where the result should be saved or rendered.
     public init(
-        contents: String,
+        source: Source,
         destination: Destination
     ) {
-        self.contents = contents
+        self.source = source
         self.destination = destination
     }
 }

--- a/Sources/ToucanSource/Models/PipelineResult.swift
+++ b/Sources/ToucanSource/Models/PipelineResult.swift
@@ -11,10 +11,31 @@ public struct PipelineResult: Sendable {
 
     /// The source material for the pipeline result.
     public enum Source: Sendable {
-        /// The original source material, source path and optional Contents
-        case asset(String, String?)
+        /// An asset source, that needs top be copied.
+        case assetFile(String)
+        /// A generated asset source
+        case asset(String)
         /// The final transformed content (e.g., HTML, Markdown, etc.).
         case content(String)
+
+        /// A Boolean value indicating whether the pipeline result's source is content-based.
+        /// Returns `true` if the source is `.content`, otherwise `false`.
+        public var isContent: Bool {
+            !isAsset
+        }
+
+        /// A Boolean value indicating whether the pipeline result's source is an asset.
+        /// Returns `true` if the source is `.asset`, otherwise `false`.
+        public var isAsset: Bool {
+            switch self {
+            case .content(_):
+                return false
+            case .assetFile(_):
+                return true
+            case .asset(_):
+                return true
+            }
+        }
     }
 
     /// The source material.
@@ -34,22 +55,5 @@ public struct PipelineResult: Sendable {
     ) {
         self.source = source
         self.destination = destination
-    }
-
-    /// A Boolean value indicating whether the pipeline result's source is content-based.
-    /// Returns `true` if the source is `.content`, otherwise `false`.
-    public var isContent: Bool {
-        switch source {
-        case .content(_):
-            return true
-        case .asset(_, _):
-            return false
-        }
-    }
-
-    /// A Boolean value indicating whether the pipeline result's source is an asset.
-    /// Returns `true` if the source is `.asset`, otherwise `false`.
-    public var isAsset: Bool {
-        !isContent
     }
 }

--- a/Sources/ToucanTesting/Templates/Templates+Page.swift
+++ b/Sources/ToucanTesting/Templates/Templates+Page.swift
@@ -22,4 +22,5 @@ public extension Templates.Mocks {
         </html>
         """
     }
+
 }

--- a/Tests/ToucanSDKTests/Toucan/ToucanAssetsTestSuite.swift
+++ b/Tests/ToucanSDKTests/Toucan/ToucanAssetsTestSuite.swift
@@ -15,6 +15,206 @@ import ToucanTesting
 struct ToucanAssetsTestSuite: ToucanTestSuite {
 
     @Test
+    func testMinifyCSSAsset() async throws {
+        let logger = Logger(label: "ToucanTestSuite")
+        try FileManagerPlayground {
+            Directory("src") {
+                Directory("contents") {
+                    Directory("page1") {
+                        File(
+                            "index.yaml",
+                            string: """
+                                title: title
+                                type: page
+                                description: Desc1
+                                label: label1
+                                """
+                        )
+                        Directory("assets") {
+                            File(
+                                "style.css",
+                                string: """
+                                    html {
+                                        margin: 0;
+                                        padding: 0;
+                                    }
+                                    body {
+                                        background: red;
+                                    }
+                                    """
+                            )
+                        }
+                    }
+                }
+                Directory("pipelines") {
+                    File(
+                        "html.yml",
+                        string: """
+                            id: html
+                            assets:
+                                behaviors:
+                                    - id: minify-css
+                                      input:
+                                        name: "style" 
+                                        ext: "css"
+                                      output:
+                                        name: "style.min"
+                                        ext: "css"
+
+                            contentTypes: 
+                                include:
+                                    - page
+                            engine: 
+                                id: mustache
+                                options:
+                                    contentTypes: 
+                                        page:
+                                            template: "pages.default"
+                            output:
+                                path: "{{slug}}"
+                                file: index
+                                ext: html
+                            """
+                    )
+                }
+                Directory("types") {
+                    typePage()
+                }
+                Directory("themes") {
+                    Directory("default") {
+                        Directory("templates") {
+                            Directory("pages") {
+                                themeDefaultMustache(svg: "{{page.svg}}")
+                            }
+                            themeHtmlMustache()
+                        }
+                    }
+                }
+                configFile()
+            }
+        }
+        .test {
+            let input = $1.appending(path: "src/")
+            let output = $1.appending(path: "docs/")
+            try getToucan(input, output, logger).generate()
+
+            let cssPath = output.appending(path: "assets/page1/style.min.css")
+            #expect($0.fileExists(at: cssPath))
+
+            let contents = try cssPath.loadContents()
+            #expect(
+                contents.contains(
+                    "html{margin:0;padding:0}body{background:red}"
+                )
+            )
+        }
+    }
+
+    @Test
+    func testSASSAsset() async throws {
+        let logger = Logger(label: "ToucanTestSuite")
+        try FileManagerPlayground {
+            Directory("src") {
+                Directory("contents") {
+                    Directory("page1") {
+                        File(
+                            "index.yaml",
+                            string: """
+                                title: title
+                                type: page
+                                description: Desc1
+                                label: label1
+                                """
+                        )
+                        Directory("assets") {
+                            File(
+                                "style.sass",
+                                string: """
+                                    $font-stack: Helvetica, sans-serif
+                                    $primary-color: #333
+
+                                    body
+                                      font: 100% $font-stack
+                                      color: $primary-color
+                                    """
+                            )
+                        }
+                    }
+                }
+                Directory("pipelines") {
+                    File(
+                        "html.yml",
+                        string: """
+                            id: html
+                            assets:
+                                behaviors:
+                                    - id: compile-sass
+                                      input:
+                                        name: "style" 
+                                        ext: "sass"
+                                      output:
+                                        name: "style.min"
+                                        ext: "css"
+
+                            contentTypes: 
+                                include:
+                                    - page
+                            engine: 
+                                id: mustache
+                                options:
+                                    contentTypes: 
+                                        page:
+                                            template: "pages.default"
+                            output:
+                                path: "{{slug}}"
+                                file: index
+                                ext: html
+                            """
+                    )
+                }
+                Directory("types") {
+                    typePage()
+                }
+                Directory("themes") {
+                    Directory("default") {
+                        Directory("templates") {
+                            Directory("pages") {
+                                themeDefaultMustache(svg: "{{page.svg}}")
+                            }
+                            themeHtmlMustache()
+                        }
+                    }
+                }
+                configFile()
+            }
+        }
+        .test {
+            let input = $1.appending(path: "src/")
+            let output = $1.appending(path: "docs/")
+            try getToucan(input, output, logger).generate()
+
+            let assetsPath = output.appending(path: "assets/page1/")
+
+            #expect($0.listDirectory(at: assetsPath).count == 1)
+
+            let cssPath = assetsPath.appending(path: "style.min.css")
+            #expect($0.fileExists(at: cssPath))
+
+            let contents = try cssPath.loadContents()
+            #expect(
+                contents.contains(
+                    """
+                    body {
+                      font: 100% Helvetica, sans-serif;
+                      color: #333;
+                    }
+                    """
+                )
+            )
+        }
+    }
+
+    @Test
     func testLoadSvg() async throws {
         let logger = Logger(label: "ToucanTestSuite")
         try FileManagerPlayground {

--- a/Tests/ToucanSDKTests/Toucan/ToucanAssetsTestSuite.swift
+++ b/Tests/ToucanSDKTests/Toucan/ToucanAssetsTestSuite.swift
@@ -240,6 +240,7 @@ struct ToucanAssetsTestSuite: ToucanTestSuite {
                         "html.yml",
                         string: """
                             id: html
+
                             contentTypes: 
                                 include:
                                     - page
@@ -250,6 +251,8 @@ struct ToucanAssetsTestSuite: ToucanTestSuite {
                                         page:
                                             template: "pages.default"
                             assets:
+                              behaviors:
+                                - id: copy
                               properties:
                                 - action: load
                                   property: svg
@@ -334,6 +337,8 @@ struct ToucanAssetsTestSuite: ToucanTestSuite {
                                         page:
                                             template: "pages.default"
                             assets:
+                              behaviors:
+                                - id: copy
                               properties:
                                 - action: load
                                   property: svg
@@ -425,6 +430,8 @@ struct ToucanAssetsTestSuite: ToucanTestSuite {
                                         page:
                                             template: "pages.default"
                             assets:
+                              behaviors:
+                                - id: copy
                               properties:
                                 - action: parse
                                   property: yaml
@@ -516,6 +523,8 @@ struct ToucanAssetsTestSuite: ToucanTestSuite {
                                         page:
                                             template: "pages.default"
                             assets:
+                              behaviors:
+                                - id: copy
                               properties:
                                 - action: parse
                                   property: yaml

--- a/Tests/ToucanSDKTests/Utilities/DateFormatterTestSuite.swift
+++ b/Tests/ToucanSDKTests/Utilities/DateFormatterTestSuite.swift
@@ -144,7 +144,7 @@ struct DateFormatterTestSuite {
             """
 
         switch results[0].source {
-        case .asset(_):
+        case .asset(_, _):
             #expect(Bool(false))
         case .content(let value):
             #expect(value == expectation)
@@ -270,7 +270,7 @@ struct DateFormatterTestSuite {
             </html>
             """
         switch results[0].source {
-        case .asset(_):
+        case .asset(_, _):
             #expect(Bool(false))
         case .content(let value):
             #expect(value == expectation)
@@ -392,7 +392,7 @@ struct DateFormatterTestSuite {
             </html>
             """
         switch results[0].source {
-        case .asset(_):
+        case .asset(_, _):
             #expect(Bool(false))
         case .content(let value):
             #expect(value == expectation)

--- a/Tests/ToucanSDKTests/Utilities/DateFormatterTestSuite.swift
+++ b/Tests/ToucanSDKTests/Utilities/DateFormatterTestSuite.swift
@@ -144,7 +144,7 @@ struct DateFormatterTestSuite {
             """
 
         switch results[0].source {
-        case .asset(_, _):
+        case .assetFile(_), .asset(_):
             #expect(Bool(false))
         case .content(let value):
             #expect(value == expectation)
@@ -270,7 +270,7 @@ struct DateFormatterTestSuite {
             </html>
             """
         switch results[0].source {
-        case .asset(_, _):
+        case .assetFile(_), .asset(_):
             #expect(Bool(false))
         case .content(let value):
             #expect(value == expectation)
@@ -392,7 +392,7 @@ struct DateFormatterTestSuite {
             </html>
             """
         switch results[0].source {
-        case .asset(_, _):
+        case .assetFile(_), .asset(_):
             #expect(Bool(false))
         case .content(let value):
             #expect(value == expectation)

--- a/Tests/ToucanSDKTests/Utilities/DateFormatterTestSuite.swift
+++ b/Tests/ToucanSDKTests/Utilities/DateFormatterTestSuite.swift
@@ -128,9 +128,8 @@ struct DateFormatterTestSuite {
 
         let results = try sourceBundleRenderer.render(now: now)
         #expect(results.count == 1)
-        let first = try #require(results.first)
 
-        let expected = """
+        let expectation = """
             <html>
                 <head>
                 </head>
@@ -143,7 +142,13 @@ struct DateFormatterTestSuite {
                 </body>
             </html>
             """
-        #expect(first.contents == expected)
+
+        switch results[0].source {
+        case .asset(_):
+            #expect(Bool(false))
+        case .content(let value):
+            #expect(value == expectation)
+        }
     }
 
     @Test
@@ -250,9 +255,8 @@ struct DateFormatterTestSuite {
 
         let results = try sourceBundleRenderer.render(now: now)
         #expect(results.count == 1)
-        let first = try #require(results.first)
 
-        let expected = """
+        let expectation = """
             <html>
                 <head>
                 </head>
@@ -265,7 +269,12 @@ struct DateFormatterTestSuite {
                 </body>
             </html>
             """
-        #expect(first.contents == expected)
+        switch results[0].source {
+        case .asset(_):
+            #expect(Bool(false))
+        case .content(let value):
+            #expect(value == expectation)
+        }
     }
 
     @Test
@@ -368,9 +377,8 @@ struct DateFormatterTestSuite {
 
         let results = try sourceBundleRenderer.render(now: now)
         #expect(results.count == 1)
-        let first = try #require(results.first)
 
-        let expected = """
+        let expectation = """
             <html>
                 <head>
                 </head>
@@ -383,6 +391,11 @@ struct DateFormatterTestSuite {
                 </body>
             </html>
             """
-        #expect(first.contents == expected)
+        switch results[0].source {
+        case .asset(_):
+            #expect(Bool(false))
+        case .content(let value):
+            #expect(value == expectation)
+        }
     }
 }

--- a/Tests/ToucanSourceTests/SourceBundle/SourceBundleAssetsTestSuite.swift
+++ b/Tests/ToucanSourceTests/SourceBundle/SourceBundleAssetsTestSuite.swift
@@ -68,7 +68,7 @@ struct SourceBundleAssetsTestSuite {
             getRawContent(["cover.jpg"])
         ]
         var renderer = getRenderer(pipelines, rawPageContents)
-        let results = try renderer.render(now: Date())
+        let results = try renderer.render(now: Date()).filter(\.isContent)
 
         #expect(results.count == 1)
 
@@ -137,7 +137,7 @@ struct SourceBundleAssetsTestSuite {
             <img src=\"{{page.image.custom2}}\">
             """
         )
-        let results = try renderer.render(now: Date())
+        let results = try renderer.render(now: Date()).filter(\.isContent)
 
         #expect(results.count == 1)
         switch results[0].source {
@@ -173,7 +173,7 @@ struct SourceBundleAssetsTestSuite {
                     properties: [
                         .init(
                             action: .add,
-                            property: "image",
+                            property: "images",
                             resolvePath: true,
                             input: .init(name: "custom", ext: "jpg")
                         )
@@ -200,8 +200,13 @@ struct SourceBundleAssetsTestSuite {
         let rawPageContents: [RawContent] = [
             getRawContent(["custom.jpg"])
         ]
-        var renderer = getRenderer(pipelines, rawPageContents)
-        let results = try renderer.render(now: Date())
+
+        var renderer = getRenderer(
+            pipelines,
+            rawPageContents,
+            "<img src=\"{{#page.images}}{{.}}{{/page.images}}\">"
+        )
+        let results = try renderer.render(now: Date()).filter(\.isContent)
 
         #expect(results.count == 1)
         switch results[0].source {
@@ -209,7 +214,7 @@ struct SourceBundleAssetsTestSuite {
             #expect(Bool(false))
         case .content(let value):
             #expect(
-                value.contains("http://localhost:3000/assets/slug/custom.png")
+                value.contains("http://localhost:3000/assets/slug/custom.jpg")
             )
         }
     }
@@ -273,7 +278,7 @@ struct SourceBundleAssetsTestSuite {
             {{/page.images}}
             """
         )
-        let results = try renderer.render(now: Date())
+        let results = try renderer.render(now: Date()).filter(\.isContent)
 
         #expect(results.count == 1)
         switch results[0].source {
@@ -347,7 +352,7 @@ struct SourceBundleAssetsTestSuite {
             <img src=\"{{page.images.custom2}}\">
             """
         )
-        let results = try renderer.render(now: Date())
+        let results = try renderer.render(now: Date()).filter(\.isContent)
 
         #expect(results.count == 1)
         switch results[0].source {

--- a/Tests/ToucanSourceTests/SourceBundle/SourceBundleAssetsTestSuite.swift
+++ b/Tests/ToucanSourceTests/SourceBundle/SourceBundleAssetsTestSuite.swift
@@ -68,12 +68,13 @@ struct SourceBundleAssetsTestSuite {
             getRawContent(["cover.jpg"])
         ]
         var renderer = getRenderer(pipelines, rawPageContents)
-        let results = try renderer.render(now: Date()).filter(\.isContent)
+        let results = try renderer.render(now: Date())
+            .filter(\.source.isContent)
 
         #expect(results.count == 1)
 
         switch results[0].source {
-        case .asset(_):
+        case .assetFile(_), .asset(_):
             #expect(Bool(false))
         case .content(let value):
             #expect(
@@ -137,11 +138,12 @@ struct SourceBundleAssetsTestSuite {
             <img src=\"{{page.image.custom2}}\">
             """
         )
-        let results = try renderer.render(now: Date()).filter(\.isContent)
+        let results = try renderer.render(now: Date())
+            .filter(\.source.isContent)
 
         #expect(results.count == 1)
         switch results[0].source {
-        case .asset(_):
+        case .assetFile(_), .asset(_):
             #expect(Bool(false))
         case .content(let value):
             #expect(
@@ -206,11 +208,12 @@ struct SourceBundleAssetsTestSuite {
             rawPageContents,
             "<img src=\"{{#page.images}}{{.}}{{/page.images}}\">"
         )
-        let results = try renderer.render(now: Date()).filter(\.isContent)
+        let results = try renderer.render(now: Date())
+            .filter(\.source.isContent)
 
         #expect(results.count == 1)
         switch results[0].source {
-        case .asset(_):
+        case .assetFile(_), .asset(_):
             #expect(Bool(false))
         case .content(let value):
             #expect(
@@ -278,11 +281,12 @@ struct SourceBundleAssetsTestSuite {
             {{/page.images}}
             """
         )
-        let results = try renderer.render(now: Date()).filter(\.isContent)
+        let results = try renderer.render(now: Date())
+            .filter(\.source.isContent)
 
         #expect(results.count == 1)
         switch results[0].source {
-        case .asset(_):
+        case .assetFile(_), .asset(_):
             #expect(Bool(false))
         case .content(let value):
             #expect(
@@ -352,11 +356,12 @@ struct SourceBundleAssetsTestSuite {
             <img src=\"{{page.images.custom2}}\">
             """
         )
-        let results = try renderer.render(now: Date()).filter(\.isContent)
+        let results = try renderer.render(now: Date())
+            .filter(\.source.isContent)
 
         #expect(results.count == 1)
         switch results[0].source {
-        case .asset(_):
+        case .assetFile(_), .asset(_):
             #expect(Bool(false))
         case .content(let value):
             #expect(

--- a/Tests/ToucanSourceTests/SourceBundle/SourceBundleAssetsTestSuite.swift
+++ b/Tests/ToucanSourceTests/SourceBundle/SourceBundleAssetsTestSuite.swift
@@ -33,6 +33,7 @@ struct SourceBundleAssetsTestSuite {
                 ),
                 iterators: [:],
                 assets: .init(
+                    behaviors: [],
                     properties: [
                         .init(
                             action: .set,
@@ -91,14 +92,17 @@ struct SourceBundleAssetsTestSuite {
                     filterRules: [:]
                 ),
                 iterators: [:],
-                assets: .init(properties: [
-                    .init(
-                        action: .set,
-                        property: "image",
-                        resolvePath: true,
-                        input: .init(name: "*", ext: "png")
-                    )
-                ]),
+                assets: .init(
+                    behaviors: [],
+                    properties: [
+                        .init(
+                            action: .set,
+                            property: "image",
+                            resolvePath: true,
+                            input: .init(name: "*", ext: "png")
+                        )
+                    ]
+                ),
                 transformers: [:],
                 engine: .init(
                     id: "mustache",
@@ -156,14 +160,17 @@ struct SourceBundleAssetsTestSuite {
                     filterRules: [:]
                 ),
                 iterators: [:],
-                assets: .init(properties: [
-                    .init(
-                        action: .add,
-                        property: "image",
-                        resolvePath: true,
-                        input: .init(name: "custom", ext: "jpg")
-                    )
-                ]),
+                assets: .init(
+                    behaviors: [],
+                    properties: [
+                        .init(
+                            action: .add,
+                            property: "image",
+                            resolvePath: true,
+                            input: .init(name: "custom", ext: "jpg")
+                        )
+                    ]
+                ),
                 transformers: [:],
                 engine: .init(
                     id: "mustache",
@@ -211,6 +218,7 @@ struct SourceBundleAssetsTestSuite {
                 ),
                 iterators: [:],
                 assets: .init(
+                    behaviors: [],
                     properties: [
                         .init(
                             action: .add,
@@ -282,6 +290,7 @@ struct SourceBundleAssetsTestSuite {
                 ),
                 iterators: [:],
                 assets: .init(
+                    behaviors: [],
                     properties: [
                         .init(
                             action: .set,

--- a/Tests/ToucanSourceTests/SourceBundle/SourceBundleAssetsTestSuite.swift
+++ b/Tests/ToucanSourceTests/SourceBundle/SourceBundleAssetsTestSuite.swift
@@ -71,10 +71,15 @@ struct SourceBundleAssetsTestSuite {
         let results = try renderer.render(now: Date())
 
         #expect(results.count == 1)
-        #expect(
-            results[0].contents
-                .contains("http://localhost:3000/assets/slug/cover.jpg")
-        )
+
+        switch results[0].source {
+        case .asset(_):
+            #expect(Bool(false))
+        case .content(let value):
+            #expect(
+                value.contains("http://localhost:3000/assets/slug/cover.jpg")
+            )
+        }
     }
 
     @Test()
@@ -135,14 +140,17 @@ struct SourceBundleAssetsTestSuite {
         let results = try renderer.render(now: Date())
 
         #expect(results.count == 1)
-        #expect(
-            results[0].contents
-                .contains("http://localhost:3000/assets/slug/custom1.png")
-        )
-        #expect(
-            results[0].contents
-                .contains("http://localhost:3000/assets/slug/custom2.png")
-        )
+        switch results[0].source {
+        case .asset(_):
+            #expect(Bool(false))
+        case .content(let value):
+            #expect(
+                value.contains("http://localhost:3000/assets/slug/custom1.png")
+            )
+            #expect(
+                value.contains("http://localhost:3000/assets/slug/custom2.png")
+            )
+        }
     }
 
     @Test()
@@ -196,10 +204,14 @@ struct SourceBundleAssetsTestSuite {
         let results = try renderer.render(now: Date())
 
         #expect(results.count == 1)
-        #expect(
-            results[0].contents
-                .contains("http://localhost:3000/assets/slug/custom.jpg")
-        )
+        switch results[0].source {
+        case .asset(_):
+            #expect(Bool(false))
+        case .content(let value):
+            #expect(
+                value.contains("http://localhost:3000/assets/slug/custom.png")
+            )
+        }
     }
 
     @Test()
@@ -264,14 +276,17 @@ struct SourceBundleAssetsTestSuite {
         let results = try renderer.render(now: Date())
 
         #expect(results.count == 1)
-        #expect(
-            results[0].contents
-                .contains("http://localhost:3000/assets/slug/custom1.png")
-        )
-        #expect(
-            results[0].contents
-                .contains("http://localhost:3000/assets/slug/custom2.png")
-        )
+        switch results[0].source {
+        case .asset(_):
+            #expect(Bool(false))
+        case .content(let value):
+            #expect(
+                value.contains("http://localhost:3000/assets/slug/custom1.png")
+            )
+            #expect(
+                value.contains("http://localhost:3000/assets/slug/custom2.png")
+            )
+        }
     }
 
     @Test()
@@ -335,14 +350,17 @@ struct SourceBundleAssetsTestSuite {
         let results = try renderer.render(now: Date())
 
         #expect(results.count == 1)
-        #expect(
-            results[0].contents
-                .contains("http://localhost:3000/assets/slug/custom1.png")
-        )
-        #expect(
-            results[0].contents
-                .contains("http://localhost:3000/assets/slug/custom2.png")
-        )
+        switch results[0].source {
+        case .asset(_):
+            #expect(Bool(false))
+        case .content(let value):
+            #expect(
+                value.contains("http://localhost:3000/assets/slug/custom1.png")
+            )
+            #expect(
+                value.contains("http://localhost:3000/assets/slug/custom2.png")
+            )
+        }
     }
 
     private func getRenderer(

--- a/Tests/ToucanSourceTests/SourceBundle/SourceBundleContextTestSuite.swift
+++ b/Tests/ToucanSourceTests/SourceBundle/SourceBundleContextTestSuite.swift
@@ -152,7 +152,7 @@ struct SourceBundleContextTestSuite {
         }
 
         switch results[0].source {
-        case .asset(_):
+        case .assetFile(_), .asset(_):
             #expect(Bool(false))
         case .content(let value):
             let data0 = try #require(value.data(using: .utf8))
@@ -180,7 +180,7 @@ struct SourceBundleContextTestSuite {
         }
 
         switch results[1].source {
-        case .asset(_):
+        case .assetFile(_), .asset(_):
             #expect(Bool(false))
         case .content(let value):
             let data1 = try #require(value.data(using: .utf8))
@@ -295,7 +295,7 @@ struct SourceBundleContextTestSuite {
         }
 
         switch results[0].source {
-        case .asset(_):
+        case .assetFile(_), .asset(_):
             #expect(Bool(false))
         case .content(let value):
             let data = try #require(value.data(using: .utf8))

--- a/Tests/ToucanSourceTests/SourceBundle/SourceBundleContextTestSuite.swift
+++ b/Tests/ToucanSourceTests/SourceBundle/SourceBundleContextTestSuite.swift
@@ -151,12 +151,17 @@ struct SourceBundleContextTestSuite {
             let context: Ctx
         }
 
-        let data0 = try #require(results[0].contents.data(using: .utf8))
-        let exp0 = try decoder.decode(Exp0.self, from: data0)
+        switch results[0].source {
+        case .asset(_):
+            #expect(Bool(false))
+        case .content(let value):
+            let data0 = try #require(value.data(using: .utf8))
+            let exp0 = try decoder.decode(Exp0.self, from: data0)
 
-        #expect(exp0.page.isCurrentURL)
-        for item in exp0.context.featured {
-            #expect(item.isCurrentURL == (exp0.page.slug == item.slug))
+            #expect(exp0.page.isCurrentURL)
+            for item in exp0.context.featured {
+                #expect(item.isCurrentURL == (exp0.page.slug == item.slug))
+            }
         }
 
         struct Exp1: Decodable {
@@ -174,11 +179,17 @@ struct SourceBundleContextTestSuite {
             let context: Ctx
         }
 
-        let data1 = try #require(results[1].contents.data(using: .utf8))
-        let exp1 = try decoder.decode(Exp1.self, from: data1)
+        switch results[1].source {
+        case .asset(_):
+            #expect(Bool(false))
+        case .content(let value):
+            let data1 = try #require(value.data(using: .utf8))
+            let exp1 = try decoder.decode(Exp1.self, from: data1)
 
-        #expect(exp1.page.isCurrentURL)
-        #expect(exp1.context.featured.allSatisfy { !$0.isCurrentURL })
+            #expect(exp1.page.isCurrentURL)
+            #expect(exp1.context.featured.allSatisfy { !$0.isCurrentURL })
+        }
+
     }
 
     @Test()
@@ -283,14 +294,19 @@ struct SourceBundleContextTestSuite {
             let site: Site
         }
 
-        let data = try #require(results[0].contents.data(using: .utf8))
-        let exp = try decoder.decode(Exp.self, from: data)
+        switch results[0].source {
+        case .asset(_):
+            #expect(Bool(false))
+        case .content(let value):
+            let data = try #require(value.data(using: .utf8))
+            let exp = try decoder.decode(Exp.self, from: data)
 
-        #expect(exp.site.generator.name == "Toucan")
-        #expect(exp.site.generator.version == GeneratorInfo.current.version)
-        #expect(
-            exp.site.generation.formats["iso8601"]
-                == isoFormatter.string(from: now)
-        )
+            #expect(exp.site.generator.name == "Toucan")
+            #expect(exp.site.generator.version == GeneratorInfo.current.version)
+            #expect(
+                exp.site.generation.formats["iso8601"]
+                    == isoFormatter.string(from: now)
+            )
+        }
     }
 }

--- a/Tests/ToucanSourceTests/SourceBundle/SourceBundlePageLinkTestSuite.swift
+++ b/Tests/ToucanSourceTests/SourceBundle/SourceBundlePageLinkTestSuite.swift
@@ -188,7 +188,7 @@ struct SourceBundlePageLinkTestSuite {
         #expect(results[0].destination.path == "posts/page/1")
 
         switch results[0].source {
-        case .asset(_):
+        case .assetFile(_), .asset(_):
             #expect(Bool(false))
         case .content(let value):
             #expect(value.contains("<title>Posts - 1 / 1 - </title>"))

--- a/Tests/ToucanSourceTests/SourceBundle/SourceBundlePageLinkTestSuite.swift
+++ b/Tests/ToucanSourceTests/SourceBundle/SourceBundlePageLinkTestSuite.swift
@@ -185,9 +185,15 @@ struct SourceBundlePageLinkTestSuite {
         let results = try renderer.render(now: now)
 
         #expect(results.count == 1)
-        #expect(results[0].contents.contains("<title>Posts - 1 / 1 - </title>"))
-        #expect(results[0].contents.contains("Values in markdown: 1 / 1"))
         #expect(results[0].destination.path == "posts/page/1")
+
+        switch results[0].source {
+        case .asset(_):
+            #expect(Bool(false))
+        case .content(let value):
+            #expect(value.contains("<title>Posts - 1 / 1 - </title>"))
+            #expect(value.contains("Values in markdown: 1 / 1"))
+        }
     }
 
 }

--- a/Tests/ToucanSourceTests/SourceBundle/SourceBundleRSSTestSuite.swift
+++ b/Tests/ToucanSourceTests/SourceBundle/SourceBundleRSSTestSuite.swift
@@ -115,9 +115,15 @@ struct SourceBundleRSSTestSuite {
             </rss>
             """#
 
-        #expect(results[0].contents == expectation)
         #expect(results[0].destination.path == "")
         #expect(results[0].destination.file == "rss")
         #expect(results[0].destination.ext == "xml")
+
+        switch results[0].source {
+        case .asset(_):
+            #expect(Bool(false))
+        case .content(let value):
+            #expect(value == expectation)
+        }
     }
 }

--- a/Tests/ToucanSourceTests/SourceBundle/SourceBundleRSSTestSuite.swift
+++ b/Tests/ToucanSourceTests/SourceBundle/SourceBundleRSSTestSuite.swift
@@ -120,7 +120,7 @@ struct SourceBundleRSSTestSuite {
         #expect(results[0].destination.ext == "xml")
 
         switch results[0].source {
-        case .asset(_):
+        case .assetFile(_), .asset(_):
             #expect(Bool(false))
         case .content(let value):
             #expect(value == expectation)

--- a/Tests/ToucanSourceTests/SourceBundle/SourceBundleRedirectTestSuite.swift
+++ b/Tests/ToucanSourceTests/SourceBundle/SourceBundleRedirectTestSuite.swift
@@ -100,7 +100,12 @@ struct SourceBundleRedirectTestSuite {
             </html>
             """#
 
-        #expect(results[0].contents == expectation)
+        switch results[0].source {
+        case .asset(_):
+            #expect(Bool(false))
+        case .content(let value):
+            #expect(value == expectation)
+        }
         #expect(results[0].destination.path == "home-2")
         #expect(results[0].destination.file == "index")
         #expect(results[0].destination.ext == "html")

--- a/Tests/ToucanSourceTests/SourceBundle/SourceBundleRedirectTestSuite.swift
+++ b/Tests/ToucanSourceTests/SourceBundle/SourceBundleRedirectTestSuite.swift
@@ -101,7 +101,7 @@ struct SourceBundleRedirectTestSuite {
             """#
 
         switch results[0].source {
-        case .asset(_):
+        case .assetFile(_), .asset(_):
             #expect(Bool(false))
         case .content(let value):
             #expect(value == expectation)

--- a/Tests/ToucanSourceTests/SourceBundle/SourceBundleScopeTestSuite.swift
+++ b/Tests/ToucanSourceTests/SourceBundle/SourceBundleScopeTestSuite.swift
@@ -182,10 +182,15 @@ struct SourceBundleScopeTestSuite {
             let context: Ctx
         }
 
-        let data0 = try #require(results[0].contents.data(using: .utf8))
-        let exp0 = try decoder.decode(Exp0.self, from: data0)
+        switch results[0].source {
+        case .asset(_):
+            #expect(Bool(false))
+        case .content(let value):
+            let data0 = try #require(value.data(using: .utf8))
+            let exp0 = try decoder.decode(Exp0.self, from: data0)
 
-        #expect(exp0.context.featured.allSatisfy { $0.isCurrentURL == nil })
+            #expect(exp0.context.featured.allSatisfy { $0.isCurrentURL == nil })
+        }
 
         struct Exp1: Decodable {
             struct Slug: Decodable {
@@ -208,8 +213,13 @@ struct SourceBundleScopeTestSuite {
             let context: Ctx
         }
 
-        let data1 = try #require(results[1].contents.data(using: .utf8))
-        let exp1 = try decoder.decode(Exp1.self, from: data1)
-        #expect(exp1.context.featured.allSatisfy { $0.isCurrentURL == nil })
+        switch results[1].source {
+        case .asset(_):
+            #expect(Bool(false))
+        case .content(let value):
+            let data1 = try #require(value.data(using: .utf8))
+            let exp1 = try decoder.decode(Exp1.self, from: data1)
+            #expect(exp1.context.featured.allSatisfy { $0.isCurrentURL == nil })
+        }
     }
 }

--- a/Tests/ToucanSourceTests/SourceBundle/SourceBundleScopeTestSuite.swift
+++ b/Tests/ToucanSourceTests/SourceBundle/SourceBundleScopeTestSuite.swift
@@ -183,7 +183,7 @@ struct SourceBundleScopeTestSuite {
         }
 
         switch results[0].source {
-        case .asset(_):
+        case .assetFile(_), .asset(_):
             #expect(Bool(false))
         case .content(let value):
             let data0 = try #require(value.data(using: .utf8))
@@ -214,7 +214,7 @@ struct SourceBundleScopeTestSuite {
         }
 
         switch results[1].source {
-        case .asset(_):
+        case .assetFile(_), .asset(_):
             #expect(Bool(false))
         case .content(let value):
             let data1 = try #require(value.data(using: .utf8))

--- a/Tests/ToucanSourceTests/SourceBundle/SourceBundleSitemapTestSuite.swift
+++ b/Tests/ToucanSourceTests/SourceBundle/SourceBundleSitemapTestSuite.swift
@@ -163,8 +163,7 @@ struct SourceBundleSitemapTestSuite {
         let nowString = sitemapFormatter.string(from: now)
 
         let pipelines = [
-            Pipeline.Mocks.html(),
-            Pipeline.Mocks.sitemap(),
+            Pipeline.Mocks.sitemap()
         ]
 
         let tagDefinition = ContentDefinition.Mocks.tag()

--- a/Tests/ToucanSourceTests/SourceBundle/SourceBundleSitemapTestSuite.swift
+++ b/Tests/ToucanSourceTests/SourceBundle/SourceBundleSitemapTestSuite.swift
@@ -136,7 +136,7 @@ struct SourceBundleSitemapTestSuite {
             """#
 
         switch results[0].source {
-        case .asset(_, _):
+        case .assetFile(_), .asset(_):
             #expect(Bool(false))
         case .content(let value):
             #expect(value == expectation)
@@ -277,7 +277,9 @@ struct SourceBundleSitemapTestSuite {
                 """#
 
             switch results[0].source {
-            case .asset(_, _):
+            case .assetFile(_):
+                #expect(Bool(false))
+            case .asset(_):
                 #expect(Bool(false))
             case .content(let value):
                 #expect(value == expectation)

--- a/Tests/ToucanSourceTests/SourceBundle/SourceBundleSitemapTestSuite.swift
+++ b/Tests/ToucanSourceTests/SourceBundle/SourceBundleSitemapTestSuite.swift
@@ -135,7 +135,12 @@ struct SourceBundleSitemapTestSuite {
             </urlset>
             """#
 
-        #expect(results[0].contents == expectation)
+        switch results[0].source {
+        case .asset(_):
+            #expect(Bool(false))
+        case .content(let value):
+            #expect(value == expectation)
+        }
         #expect(results[0].destination.path == "")
         #expect(results[0].destination.file == "sitemap")
         #expect(results[0].destination.ext == "xml")
@@ -272,7 +277,12 @@ struct SourceBundleSitemapTestSuite {
                 </urlset>
                 """#
 
-            #expect(sitemap.contents == expectation)
+            switch results[0].source {
+            case .asset(_):
+                #expect(Bool(false))
+            case .content(let value):
+                #expect(value == expectation)
+            }
             #expect(sitemap.destination.path == "")
             #expect(sitemap.destination.file == "sitemap")
             #expect(sitemap.destination.ext == "xml")

--- a/Tests/ToucanSourceTests/SourceBundle/SourceBundleSitemapTestSuite.swift
+++ b/Tests/ToucanSourceTests/SourceBundle/SourceBundleSitemapTestSuite.swift
@@ -136,7 +136,7 @@ struct SourceBundleSitemapTestSuite {
             """#
 
         switch results[0].source {
-        case .asset(_):
+        case .asset(_, _):
             #expect(Bool(false))
         case .content(let value):
             #expect(value == expectation)
@@ -277,7 +277,7 @@ struct SourceBundleSitemapTestSuite {
                 """#
 
             switch results[0].source {
-            case .asset(_):
+            case .asset(_, _):
                 #expect(Bool(false))
             case .content(let value):
                 #expect(value == expectation)


### PR DESCRIPTION
- new asset behaviors
- sass / scss support (`compile-sass`)
- css minification support (`minify-css`)

```yml
# in a pipeline yml
assets
    behaviors:
        - id: compile-sass 
          input:
            name: "application" 
            ext: "sass"
          output:
            name: "application"
            ext: "css"
        - id: minify-css  
          input:
            name: "style" 
            ext: "css"
          output:
            name: "style.min"
            ext: "css"
        - id: copy #default
          input:
            path: "*"
            name: "*" 
            ext: "*"
          output:
            path: "*"
            name: "*"
            ext: "*"
```

> NOTE: The corresponding behavior will be executed if there is a match on the file path, name, or extension. Copy runs by default, so there is no need to specify it explicitly. This is purely an addition to the Toucan generator.
