### PR TITLE
Implement noindex & skip brackets

### DIFF
--- a/Sources/ToucanFileSystem/Locators/FileLocator.swift
+++ b/Sources/ToucanFileSystem/Locators/FileLocator.swift
@@ -39,7 +39,8 @@ public struct FileLocator {
     /// - Parameters: url: The URL of the directory to search.
     /// - Returns: An array of file names that match the specified criteria.
     public func locate(at url: URL) -> [String] {
-        fileManager
+        return
+            fileManager
             .listDirectory(at: url)
             .filter { fileName in
                 let fileUrl = URL(fileURLWithPath: fileName)

--- a/Tests/ToucanFileSystemTests/RawContentLocatorTestSuite.swift
+++ b/Tests/ToucanFileSystemTests/RawContentLocatorTestSuite.swift
@@ -26,6 +26,74 @@ struct RawContentLocatorTestSuite {
     }
 
     @Test()
+    func rawContentLocatorTrimmingBrackets() async throws {
+        try FileManagerPlayground {
+            Directory("src") {
+                Directory("contents") {
+                    Directory("[01]blog") {
+                        Directory("[01]articles") {
+                            Directory("[01]first-beta-release") {
+                                File("index.markdown")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .test {
+            let url = $1.appending(path: "src/contents/")
+            let locator = RawContentLocator(fileManager: $0)
+            let results = locator.locate(at: url)
+
+            #expect(results.count == 1)
+
+            let result = try #require(results.first)
+            let expected = RawContentLocation(
+                slug: "blog/articles/first-beta-release",
+                markdown:
+                    "[01]blog/[01]articles/[01]first-beta-release/index.markdown"
+                    .replacingOccurrences(["[": "%5B", "]": "%5D"])
+            )
+
+            #expect(result == expected)
+        }
+    }
+
+    @Test()
+    func rawContentLocatorNoindexBrackets() async throws {
+        try FileManagerPlayground {
+            Directory("src") {
+                Directory("contents") {
+                    Directory("[01]blog") {
+                        Directory("[articles]") {
+                            Directory("[01]first-beta-release") {
+                                File("index.markdown")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .test {
+            let url = $1.appending(path: "src/contents/")
+            let locator = RawContentLocator(fileManager: $0)
+            let results = locator.locate(at: url)
+
+            #expect(results.count == 1)
+
+            let result = try #require(results.first)
+            let expected = RawContentLocation(
+                slug: "blog/first-beta-release",
+                markdown:
+                    "[01]blog/[articles]/[01]first-beta-release/index.markdown"
+                    .replacingOccurrences(["[": "%5B", "]": "%5D"])
+            )
+
+            #expect(result == expected)
+        }
+    }
+
+    @Test()
     func rawContentLocatorMarkdownOnly() async throws {
         try FileManagerPlayground {
             Directory("src") {


### PR DESCRIPTION
Implements bracket support for folder names. With a bracket you can skip or ignore parts of the slug, see the following use-cases:

1. The `blog/[2025]/[01]/example-post` folder structure means the `blog/example-post` slug. This way you don't need to add `noindex.yml` files in the 2025, and 01 folders.

2. Use [] to hide extra stuff from the slug, e.g. `[01]example-post` -> `example-post`. This is extremely useful when we have ordered content and want to keep the directories in sync with the order. 