### PR TITLE
Fix front matter keys for views

### DIFF
--- a/Sources/ToucanSDK/Outputs/ContextBundleToHTMLRenderer.swift
+++ b/Sources/ToucanSDK/Outputs/ContextBundleToHTMLRenderer.swift
@@ -48,8 +48,9 @@ struct ContextBundleToHTMLRenderer {
         )
         let frontMatter = contextBundle.content.rawValue.markdown.frontMatter
         let contentTypeView = contentTypeOptions.string("view")
+        let genericContentView = frontMatter.string("views.*")
         let contentView = frontMatter.string(pipelineViewKey)
-        let viewId = contentView ?? contentTypeView
+        let viewId = contentView ?? genericContentView ?? contentTypeView
 
         guard let viewId, !viewId.isEmpty else {
             logger.warning(

--- a/Sources/ToucanSDK/Outputs/ContextBundleToHTMLRenderer.swift
+++ b/Sources/ToucanSDK/Outputs/ContextBundleToHTMLRenderer.swift
@@ -10,9 +10,10 @@ import Logging
 import ToucanSource
 
 struct ContextBundleToHTMLRenderer {
-    let mustacheTemplateRenderer: MustacheTemplateRenderer
-    let contentTypesOptions: [String: AnyCodable]
 
+    let mustacheRenderer: MustacheRenderer
+    let engineContentTypesOptions: [String: AnyCodable]
+    let pipelineViewKey: String
     let logger: Logger
 
     init(
@@ -20,13 +21,16 @@ struct ContextBundleToHTMLRenderer {
         templates: [String: String],
         logger: Logger
     ) throws {
-        self.mustacheTemplateRenderer = try MustacheTemplateRenderer(
+        self.mustacheRenderer = try MustacheRenderer(
             templates: templates.mapValues {
                 try .init(string: $0)
             },
             logger: logger
         )
-        self.contentTypesOptions = pipeline.engine.options.dict("contentTypes")
+
+        let engineOptions = pipeline.engine.options
+        self.engineContentTypesOptions = engineOptions.dict("contentTypes")
+        self.pipelineViewKey = ["views", pipeline.id].joined(separator: ".")
         self.logger = logger
     }
 
@@ -39,19 +43,17 @@ struct ContextBundleToHTMLRenderer {
     func render(
         _ contextBundle: ContextBundle
     ) -> PipelineResult? {
-        let bundleOptions = contentTypesOptions.dict(
+        let contentTypeOptions = engineContentTypesOptions.dict(
             contextBundle.content.type.id
         )
+        let frontMatter = contextBundle.content.rawValue.markdown.frontMatter
+        let contentTypeView = contentTypeOptions.string("view")
+        let contentView = frontMatter.string(pipelineViewKey)
+        let viewId = contentView ?? contentTypeView
 
-        let contentTypeTemplate = bundleOptions.string("view")
-        let contentTemplate = contextBundle.content.rawValue.markdown
-            .frontMatter
-            .string("view")
-        let template = contentTemplate ?? contentTypeTemplate
-
-        guard let template, !template.isEmpty else {
+        guard let viewId, !viewId.isEmpty else {
             logger.warning(
-                "Missing mustache template file.",
+                "No view has been specified for this content.",
                 metadata: [
                     "slug": "\(contextBundle.content.slug)",
                     "type": "\(contextBundle.content.type.id)",
@@ -60,18 +62,18 @@ struct ContextBundleToHTMLRenderer {
             return nil
         }
 
-        let html = mustacheTemplateRenderer.render(
-            template: template,
+        let html = mustacheRenderer.render(
+            using: viewId,
             with: contextBundle.context
         )
 
-        guard let html, !html.isEmpty else {
+        guard let html else {
             logger.warning(
-                "Could not get valid HTML from content using template.",
+                "Could not get valid HTML from content using view.",
                 metadata: [
-                    "slug": "\(contextBundle.content.slug)",
-                    "type": "\(contextBundle.content.type.id)",
-                    "view": "\(template)",
+                    "slug": .string(contextBundle.content.slug.value),
+                    "type": .string(contextBundle.content.type.id),
+                    "view": .string(viewId),
                 ]
             )
             return nil

--- a/Sources/ToucanSDK/Outputs/ContextBundleToHTMLRenderer.swift
+++ b/Sources/ToucanSDK/Outputs/ContextBundleToHTMLRenderer.swift
@@ -30,21 +30,23 @@ struct ContextBundleToHTMLRenderer {
         self.logger = logger
     }
 
-    func render(_ contextBundles: [ContextBundle]) -> [PipelineResult] {
-        contextBundles.compactMap {
-            render($0)
-        }
+    func render(
+        _ contextBundles: [ContextBundle]
+    ) -> [PipelineResult] {
+        contextBundles.compactMap { render($0) }
     }
 
-    func render(_ contextBundle: ContextBundle) -> PipelineResult? {
+    func render(
+        _ contextBundle: ContextBundle
+    ) -> PipelineResult? {
         let bundleOptions = contentTypesOptions.dict(
             contextBundle.content.type.id
         )
 
-        let contentTypeTemplate = bundleOptions.string("template")
+        let contentTypeTemplate = bundleOptions.string("view")
         let contentTemplate = contextBundle.content.rawValue.markdown
             .frontMatter
-            .string("template")
+            .string("view")
         let template = contentTemplate ?? contentTypeTemplate
 
         guard let template, !template.isEmpty else {
@@ -69,7 +71,7 @@ struct ContextBundleToHTMLRenderer {
                 metadata: [
                     "slug": "\(contextBundle.content.slug)",
                     "type": "\(contextBundle.content.type.id)",
-                    "template": "\(template)",
+                    "view": "\(template)",
                 ]
             )
             return nil

--- a/Sources/ToucanSDK/Renderers/MustacheRenderer.swift
+++ b/Sources/ToucanSDK/Renderers/MustacheRenderer.swift
@@ -49,7 +49,7 @@ public struct MustacheRenderer {
         using id: String,
         with object: [String: AnyCodable]
     ) -> String? {
-        // Ensure the template ID is valid
+        // Ensure the ID is valid
         guard ids.contains(id) else {
             logger.error(
                 "Missing or invalid template file.",

--- a/Sources/ToucanSDK/Renderers/MustacheRenderer.swift
+++ b/Sources/ToucanSDK/Renderers/MustacheRenderer.swift
@@ -1,5 +1,5 @@
 //
-//  MustacheTemplateRenderer.swift
+//  MustacheRenderer.swift
 //  Toucan
 //
 //  Created by Tibor Bödecs on 2025. 02. 16..
@@ -11,7 +11,7 @@ import Mustache
 import ToucanSource
 
 /// Renders Mustache templates using a predefined template library and a dynamic context object.
-public struct MustacheTemplateRenderer {
+public struct MustacheRenderer {
     /// A list of all available template IDs in the library.
     var ids: [String]
 
@@ -42,19 +42,19 @@ public struct MustacheTemplateRenderer {
     /// Renders a Mustache template using the given context object.
     ///
     /// - Parameters:
-    ///   - template: The ID of the template to render.
+    ///   - id: The ID of the template to render.
     ///   - object: A dictionary representing the context (`[String: AnyCodable]`).
     /// - Returns: The rendered HTML string, or `nil` if rendering fails or the template is missing.
     public func render(
-        template: String,
+        using id: String,
         with object: [String: AnyCodable]
     ) -> String? {
         // Ensure the template ID is valid
-        guard ids.contains(template) else {
+        guard ids.contains(id) else {
             logger.error(
                 "Missing or invalid template file.",
                 metadata: [
-                    "id": "\(template)"
+                    "id": .string(id)
                 ]
             )
             return nil
@@ -64,16 +64,15 @@ public struct MustacheTemplateRenderer {
         let local = unwrap(object) as Any
 
         // Attempt rendering using the Mustache library
-        guard let html = library.render(local, withTemplate: template) else {
+        guard let html = library.render(local, withTemplate: id) else {
             logger.error(
                 "Could not render HTML using the template file.",
                 metadata: [
-                    "id": "\(template)"
+                    "id": .string(id)
                 ]
             )
             return nil
         }
-
         return html
     }
 }

--- a/Sources/ToucanSource/ObjectLoader.swift
+++ b/Sources/ToucanSource/ObjectLoader.swift
@@ -66,7 +66,7 @@ public struct ObjectLoader {
             return
                 try locations
                 .map {
-                    let fileURL = url.appendingPathComponent($0)
+                    let fileURL = url.appendingPathIfPresent($0)
                     lastURL = fileURL
                     return fileURL
                 }
@@ -98,7 +98,7 @@ public struct ObjectLoader {
             let combinedRawCodableObject =
                 try locations
                 .map {
-                    let fileURL = url.appendingPathComponent($0)
+                    let fileURL = url.appendingPathIfPresent($0)
                     lastURL = fileURL
                     return fileURL
                 }

--- a/Sources/ToucanSource/Objects/Config/Config.swift
+++ b/Sources/ToucanSource/Objects/Config/Config.swift
@@ -78,14 +78,14 @@ public struct Config: Codable, Equatable {
     ///   - dataTypes: Data type related configurations.
     ///   - renderer: Fine-grained control for specific content types.
     public init(
-        site: Site,
-        pipelines: Pipelines,
-        contents: Contents,
-        types: Types,
-        blocks: Blocks,
-        templates: Templates,
-        dataTypes: DataTypes,
-        renderer: RendererConfig
+        site: Site = .defaults,
+        pipelines: Pipelines = .defaults,
+        contents: Contents = .defaults,
+        types: Types = .defaults,
+        blocks: Blocks = .defaults,
+        templates: Templates = .defaults,
+        dataTypes: DataTypes = .defaults,
+        renderer: RendererConfig = .defaults
     ) {
         self.site = site
         self.pipelines = pipelines

--- a/Sources/ToucanSource/Objects/Pipeline/Pipeline+Assets.swift
+++ b/Sources/ToucanSource/Objects/Pipeline/Pipeline+Assets.swift
@@ -198,8 +198,8 @@ public extension Pipeline {
         ///   - behaviors: The array of asset behaviors.
         ///   - properties: The array of asset properties to include.
         public init(
-            behaviors: [Behavior],
-            properties: [Property]
+            behaviors: [Behavior] = [],
+            properties: [Property] = []
         ) {
             self.behaviors = behaviors
             self.properties = properties

--- a/Sources/ToucanSource/Objects/Pipeline/Pipeline+Engine.swift
+++ b/Sources/ToucanSource/Objects/Pipeline/Pipeline+Engine.swift
@@ -33,7 +33,7 @@ public extension Pipeline {
         ///   - options: A dictionary of custom configuration options.
         public init(
             id: String,
-            options: [String: AnyCodable]
+            options: [String: AnyCodable] = [:]
         ) {
             self.id = id
             self.options = options

--- a/Sources/ToucanSource/Objects/Pipeline/Pipeline.swift
+++ b/Sources/ToucanSource/Objects/Pipeline/Pipeline.swift
@@ -66,14 +66,14 @@ public struct Pipeline: Codable {
     /// Initializes a fully-defined `Pipeline` object.
     public init(
         id: String,
-        definesType: Bool,
-        scopes: [String: [String: Scope]],
-        queries: [String: Query],
-        dataTypes: DataTypes,
-        contentTypes: ContentTypes,
-        iterators: [String: Query],
-        assets: Assets,
-        transformers: [String: Transformers],
+        definesType: Bool = false,
+        scopes: [String: [String: Scope]] = [:],
+        queries: [String: Query] = [:],
+        dataTypes: DataTypes = .defaults,
+        contentTypes: ContentTypes = .defaults,
+        iterators: [String: Query] = [:],
+        assets: Assets = .defaults,
+        transformers: [String: Transformers] = [:],
         engine: Engine,
         output: Output
     ) {

--- a/Tests/ToucanSDKTests/E2ETestSuite.swift
+++ b/Tests/ToucanSDKTests/E2ETestSuite.swift
@@ -298,33 +298,32 @@ struct E2ETestSuite {
 
     // MARK: - assets
 
+    private func mockSiteYAMLFile() -> YAMLFile<Settings> {
+        .init(
+            name: "site",
+            contents: Settings(
+                [
+                    "name": "Test site name",
+                    "description": "Test site description",
+                    "language": "en-US",
+                ]
+            )
+        )
+    }
+
     @Test
     func loadOneSVGFile() async throws {
         let now = Date()
 
         try FileManagerPlayground {
             Directory(name: "src") {
-                YAMLFile(
-                    name: "site",
-                    contents: [
-                        "name": "Test site name",
-                        "description": "Test site description",
-                        "language": "en-US",
-                    ] as [String: AnyCodable]
-                )
+                mockSiteYAMLFile()
                 Directory(name: "pipelines") {
                     YAMLFile(
                         name: "test",
                         contents: Pipeline(
                             id: "test",
-                            definesType: false,
-                            scopes: [:],
-                            queries: [:],
-                            dataTypes: .defaults,
-                            contentTypes: .defaults,
-                            iterators: [:],
                             assets: .init(
-                                behaviors: [],
                                 properties: [
                                     .init(
                                         action: .load,
@@ -338,7 +337,6 @@ struct E2ETestSuite {
                                     )
                                 ]
                             ),
-                            transformers: [:],
                             engine: .init(
                                 id: "json",
                                 options: [
@@ -413,27 +411,13 @@ struct E2ETestSuite {
 
         try FileManagerPlayground {
             Directory(name: "src") {
-                YAMLFile(
-                    name: "site",
-                    contents: [
-                        "name": "Test site name",
-                        "description": "Test site description",
-                        "language": "en-US",
-                    ] as [String: AnyCodable]
-                )
+                mockSiteYAMLFile()
                 Directory(name: "pipelines") {
                     YAMLFile(
                         name: "test",
                         contents: Pipeline(
                             id: "test",
-                            definesType: false,
-                            scopes: [:],
-                            queries: [:],
-                            dataTypes: .defaults,
-                            contentTypes: .defaults,
-                            iterators: [:],
                             assets: .init(
-                                behaviors: [],
                                 properties: [
                                     .init(
                                         action: .load,
@@ -531,27 +515,13 @@ struct E2ETestSuite {
 
         try FileManagerPlayground {
             Directory(name: "src") {
-                YAMLFile(
-                    name: "site",
-                    contents: [
-                        "name": "Test site name",
-                        "description": "Test site description",
-                        "language": "en-US",
-                    ] as [String: AnyCodable]
-                )
+                mockSiteYAMLFile()
                 Directory(name: "pipelines") {
                     YAMLFile(
                         name: "test",
                         contents: Pipeline(
                             id: "test",
-                            definesType: false,
-                            scopes: [:],
-                            queries: [:],
-                            dataTypes: .defaults,
-                            contentTypes: .defaults,
-                            iterators: [:],
                             assets: .init(
-                                behaviors: [],
                                 properties: [
                                     .init(
                                         action: .parse,
@@ -565,7 +535,6 @@ struct E2ETestSuite {
                                     )
                                 ]
                             ),
-                            transformers: [:],
                             engine: .init(
                                 id: "json",
                                 options: [
@@ -639,27 +608,13 @@ struct E2ETestSuite {
 
         try FileManagerPlayground {
             Directory(name: "src") {
-                YAMLFile(
-                    name: "site",
-                    contents: [
-                        "name": "Test site name",
-                        "description": "Test site description",
-                        "language": "en-US",
-                    ] as [String: AnyCodable]
-                )
+                mockSiteYAMLFile()
                 Directory(name: "pipelines") {
                     YAMLFile(
                         name: "test",
                         contents: Pipeline(
                             id: "test",
-                            definesType: false,
-                            scopes: [:],
-                            queries: [:],
-                            dataTypes: .defaults,
-                            contentTypes: .defaults,
-                            iterators: [:],
                             assets: .init(
-                                behaviors: [],
                                 properties: [
                                     .init(
                                         action: .parse,
@@ -673,7 +628,6 @@ struct E2ETestSuite {
                                     )
                                 ]
                             ),
-                            transformers: [:],
                             engine: .init(
                                 id: "json",
                                 options: [
@@ -754,25 +708,12 @@ struct E2ETestSuite {
 
         try FileManagerPlayground {
             Directory(name: "src") {
-                YAMLFile(
-                    name: "site",
-                    contents: [
-                        "name": "Test site name",
-                        "description": "Test site description",
-                        "language": "en-US",
-                    ] as [String: AnyCodable]
-                )
+                mockSiteYAMLFile()
                 Directory(name: "pipelines") {
                     YAMLFile(
                         name: "test",
                         contents: Pipeline(
                             id: "test",
-                            definesType: false,
-                            scopes: [:],
-                            queries: [:],
-                            dataTypes: .defaults,
-                            contentTypes: .defaults,
-                            iterators: [:],
                             assets: .init(
                                 behaviors: [
                                     .init(
@@ -786,10 +727,8 @@ struct E2ETestSuite {
                                             ext: "css"
                                         )
                                     )
-                                ],
-                                properties: []
+                                ]
                             ),
-                            transformers: [:],
                             engine: .init(
                                 id: "json",
                                 options: [
@@ -866,25 +805,12 @@ struct E2ETestSuite {
 
         try FileManagerPlayground {
             Directory(name: "src") {
-                YAMLFile(
-                    name: "site",
-                    contents: [
-                        "name": "Test site name",
-                        "description": "Test site description",
-                        "language": "en-US",
-                    ] as [String: AnyCodable]
-                )
+                mockSiteYAMLFile()
                 Directory(name: "pipelines") {
                     YAMLFile(
                         name: "test",
                         contents: Pipeline(
                             id: "test",
-                            definesType: false,
-                            scopes: [:],
-                            queries: [:],
-                            dataTypes: .defaults,
-                            contentTypes: .defaults,
-                            iterators: [:],
                             assets: .init(
                                 behaviors: [
                                     .init(
@@ -898,10 +824,8 @@ struct E2ETestSuite {
                                             ext: "css"
                                         )
                                     )
-                                ],
-                                properties: []
+                                ]
                             ),
-                            transformers: [:],
                             engine: .init(
                                 id: "json",
                                 options: [
@@ -982,25 +906,12 @@ struct E2ETestSuite {
 
         try FileManagerPlayground {
             Directory(name: "src") {
-                YAMLFile(
-                    name: "site",
-                    contents: [
-                        "name": "Test site name",
-                        "description": "Test site description",
-                        "language": "en-US",
-                    ] as [String: AnyCodable]
-                )
+                mockSiteYAMLFile()
                 Directory(name: "pipelines") {
                     YAMLFile(
                         name: "test",
                         contents: Pipeline(
                             id: "test",
-                            definesType: false,
-                            scopes: [:],
-                            queries: [:],
-                            dataTypes: .defaults,
-                            contentTypes: .defaults,
-                            iterators: [:],
                             assets: .init(
                                 behaviors: [
                                     .init(
@@ -1014,10 +925,8 @@ struct E2ETestSuite {
                                             ext: "css"
                                         )
                                     )
-                                ],
-                                properties: []
+                                ]
                             ),
-                            transformers: [:],
                             engine: .init(
                                 id: "json",
                                 options: [
@@ -1096,10 +1005,92 @@ struct E2ETestSuite {
         }
     }
 
+    // MARK: - custom view
+
+    @Test
+    func customView() async throws {
+        let now = Date()
+
+        try FileManagerPlayground {
+            Directory(name: "src") {
+                mockSiteYAMLFile()
+                Directory(name: "pipelines") {
+                    YAMLFile(
+                        name: "test",
+                        contents: Pipeline(
+                            id: "test",
+                            engine: .init(
+                                id: "mustache",
+                                options: [
+                                    "contentTypes": [
+                                        "test": [
+                                            "view": "test"
+                                        ]
+                                    ]
+                                ]
+                            ),
+                            output: .init(
+                                path: "{{slug}}",
+                                file: "index",
+                                ext: "html"
+                            )
+                        )
+                    )
+                }
+                Directory(name: "types") {
+                    YAMLFile(
+                        name: "test",
+                        contents: ContentType(
+                            id: "test",
+                            default: true
+                        )
+                    )
+                }
+                Directory(name: "contents") {
+                    Directory(name: "test") {
+                        File(
+                            name: "index.yaml",
+                            string: """
+                                type: test
+                                description: Desc1
+
+                                view: foo
+                                """
+                        )
+                    }
+                }
+                Directory(name: "templates") {
+                    Directory(name: "default") {
+                        Directory(name: "views") {
+                            MustacheFile(
+                                name: "foo",
+                                contents: """
+                                    lorem ipsum
+                                    """
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        .test {
+            let input = $1.appendingPathIfPresent("src")
+            try Toucan(input: input.path()).generate(now: now)
+
+            let output = $1.appendingPathIfPresent("docs")
+
+            let fileURL = output.appendingPathIfPresent("test/index.html")
+            let html = try String(contentsOf: fileURL)
+
+            print(html)
+            #expect(html.contains("lorem ipsum"))
+        }
+    }
+
     // MARK: - transformers
 
     @Test
-    func transformerRunTest() async throws {
+    func transformerExecution() async throws {
         let now = Date()
         let fileManager = FileManager.default
         let rootURL = FileManager.default.temporaryDirectory
@@ -1111,26 +1102,13 @@ struct E2ETestSuite {
             fileManager: fileManager
         ) {
             Directory(name: "src") {
-                YAMLFile(
-                    name: "site",
-                    contents: [
-                        "name": "Test site name",
-                        "description": "Test site description",
-                        "language": "en-US",
-                    ] as [String: AnyCodable]
-                )
+                mockSiteYAMLFile()
                 Directory(name: "pipelines") {
                     YAMLFile(
                         name: "test",
                         contents: Pipeline(
                             id: "test",
-                            definesType: false,
-                            scopes: [:],
-                            queries: [:],
-                            dataTypes: .defaults,
-                            contentTypes: .defaults,
-                            iterators: [:],
-                            assets: .defaults,
+
                             transformers: [
                                 "test": .init(
                                     run: [
@@ -1282,20 +1260,12 @@ struct E2ETestSuite {
 
         try FileManagerPlayground {
             Directory(name: "src") {
-                YAMLFile(
-                    name: "site",
-                    contents: [
-                        "name": "Test site name",
-                        "description": "Test site description",
-                        "language": "en-US",
-                    ] as [String: AnyCodable]
-                )
+                mockSiteYAMLFile()
                 Directory(name: "pipelines") {
                     YAMLFile(
                         name: "test",
                         contents: Pipeline(
                             id: "test",
-                            definesType: false,
                             scopes: [
                                 "test": [
                                     "minimal": .init(
@@ -1319,14 +1289,8 @@ struct E2ETestSuite {
                                     scope: "minimal"
                                 )
                             ],
-                            dataTypes: .defaults,
-                            contentTypes: .defaults,
-                            iterators: [:],
-                            assets: .defaults,
-                            transformers: [:],
                             engine: .init(
-                                id: "json",
-                                options: [:]
+                                id: "json"
                             ),
                             output: .init(
                                 path: "",
@@ -1450,14 +1414,6 @@ struct E2ETestSuite {
                         name: "test",
                         contents: Pipeline(
                             id: "test",
-                            definesType: false,
-                            scopes: [:],
-                            queries: [:],
-                            dataTypes: .defaults,
-                            contentTypes: .defaults,
-                            iterators: [:],
-                            assets: .defaults,
-                            transformers: [:],
                             engine: .init(
                                 id: "json",
                                 options: [:]
@@ -1544,12 +1500,6 @@ struct E2ETestSuite {
                 YAMLFile(
                     name: "config",
                     contents: Config(
-                        site: .defaults,
-                        pipelines: .defaults,
-                        contents: .defaults,
-                        types: .defaults,
-                        blocks: .defaults,
-                        templates: .defaults,
                         dataTypes: .init(
                             date: .init(
                                 input: .defaults,
@@ -1578,9 +1528,6 @@ struct E2ETestSuite {
                         name: "test",
                         contents: Pipeline(
                             id: "test",
-                            definesType: false,
-                            scopes: [:],
-                            queries: [:],
                             dataTypes: .init(
                                 date: .init(
                                     output: .init(
@@ -1590,10 +1537,6 @@ struct E2ETestSuite {
                                     formats: [:]
                                 )
                             ),
-                            contentTypes: .defaults,
-                            iterators: [:],
-                            assets: .defaults,
-                            transformers: [:],
                             engine: .init(
                                 id: "json",
                                 options: [:]

--- a/Tests/ToucanSDKTests/E2ETestSuite.swift
+++ b/Tests/ToucanSDKTests/E2ETestSuite.swift
@@ -311,6 +311,18 @@ struct E2ETestSuite {
         )
     }
 
+    private func mockTestTypes() -> Directory {
+        Directory(name: "types") {
+            YAMLFile(
+                name: "test",
+                contents: ContentType(
+                    id: "test",
+                    default: true
+                )
+            )
+        }
+    }
+
     @Test
     func loadOneSVGFile() async throws {
         let now = Date()
@@ -351,15 +363,7 @@ struct E2ETestSuite {
                         )
                     )
                 }
-                Directory(name: "types") {
-                    YAMLFile(
-                        name: "test",
-                        contents: ContentType(
-                            id: "test",
-                            default: true
-                        )
-                    )
-                }
+                mockTestTypes()
                 Directory(name: "contents") {
                     RawContentBundle(
                         name: "test",
@@ -446,15 +450,7 @@ struct E2ETestSuite {
                         )
                     )
                 }
-                Directory(name: "types") {
-                    YAMLFile(
-                        name: "test",
-                        contents: ContentType(
-                            id: "test",
-                            default: true
-                        )
-                    )
-                }
+                mockTestTypes()
                 Directory(name: "contents") {
                     RawContentBundle(
                         name: "test",
@@ -549,15 +545,7 @@ struct E2ETestSuite {
                         )
                     )
                 }
-                Directory(name: "types") {
-                    YAMLFile(
-                        name: "test",
-                        contents: ContentType(
-                            id: "test",
-                            default: true
-                        )
-                    )
-                }
+                mockTestTypes()
                 Directory(name: "contents") {
                     Directory(name: "test") {
                         Directory(name: "assets") {
@@ -642,15 +630,7 @@ struct E2ETestSuite {
                         )
                     )
                 }
-                Directory(name: "types") {
-                    YAMLFile(
-                        name: "test",
-                        contents: ContentType(
-                            id: "test",
-                            default: true
-                        )
-                    )
-                }
+                mockTestTypes()
                 Directory(name: "contents") {
                     Directory(name: "test") {
                         Directory(name: "assets") {
@@ -743,15 +723,7 @@ struct E2ETestSuite {
                         )
                     )
                 }
-                Directory(name: "types") {
-                    YAMLFile(
-                        name: "test",
-                        contents: ContentType(
-                            id: "test",
-                            default: true
-                        )
-                    )
-                }
+                mockTestTypes()
                 Directory(name: "contents") {
                     Directory(name: "test") {
                         Directory(name: "assets") {
@@ -840,15 +812,7 @@ struct E2ETestSuite {
                         )
                     )
                 }
-                Directory(name: "types") {
-                    YAMLFile(
-                        name: "test",
-                        contents: ContentType(
-                            id: "test",
-                            default: true
-                        )
-                    )
-                }
+                mockTestTypes()
                 Directory(name: "contents") {
                     Directory(name: "test") {
                         Directory(name: "assets") {
@@ -941,15 +905,7 @@ struct E2ETestSuite {
                         )
                     )
                 }
-                Directory(name: "types") {
-                    YAMLFile(
-                        name: "test",
-                        contents: ContentType(
-                            id: "test",
-                            default: true
-                        )
-                    )
-                }
+                mockTestTypes()
                 Directory(name: "contents") {
                     Directory(name: "test") {
                         Directory(name: "assets") {
@@ -1016,15 +972,15 @@ struct E2ETestSuite {
                 mockSiteYAMLFile()
                 Directory(name: "pipelines") {
                     YAMLFile(
-                        name: "test",
+                        name: "html",
                         contents: Pipeline(
-                            id: "test",
+                            id: "html",
                             engine: .init(
                                 id: "mustache",
                                 options: [
                                     "contentTypes": [
                                         "test": [
-                                            "view": "test"
+                                            "view": "foo"
                                         ]
                                     ]
                                 ]
@@ -1037,24 +993,14 @@ struct E2ETestSuite {
                         )
                     )
                 }
-                Directory(name: "types") {
-                    YAMLFile(
-                        name: "test",
-                        contents: ContentType(
-                            id: "test",
-                            default: true
-                        )
-                    )
-                }
+                mockTestTypes()
                 Directory(name: "contents") {
                     Directory(name: "test") {
                         File(
                             name: "index.yaml",
                             string: """
-                                type: test
-                                description: Desc1
-
-                                view: foo
+                                views:
+                                    html: bar
                                 """
                         )
                     }
@@ -1065,7 +1011,13 @@ struct E2ETestSuite {
                             MustacheFile(
                                 name: "foo",
                                 contents: """
-                                    lorem ipsum
+                                    foo
+                                    """
+                            )
+                            MustacheFile(
+                                name: "bar",
+                                contents: """
+                                    bar
                                     """
                             )
                         }
@@ -1082,8 +1034,7 @@ struct E2ETestSuite {
             let fileURL = output.appendingPathIfPresent("test/index.html")
             let html = try String(contentsOf: fileURL)
 
-            print(html)
-            #expect(html.contains("lorem ipsum"))
+            #expect(html.contains("bar"))
         }
     }
 
@@ -1139,15 +1090,7 @@ struct E2ETestSuite {
                         )
                     )
                 }
-                Directory(name: "types") {
-                    YAMLFile(
-                        name: "test",
-                        contents: ContentType(
-                            id: "test",
-                            default: true
-                        )
-                    )
-                }
+                mockTestTypes()
                 Directory(name: "contents") {
                     Directory(name: "test") {
                         File(
@@ -1300,15 +1243,7 @@ struct E2ETestSuite {
                         )
                     )
                 }
-                Directory(name: "types") {
-                    YAMLFile(
-                        name: "test",
-                        contents: ContentType(
-                            id: "test",
-                            default: true
-                        )
-                    )
-                }
+                mockTestTypes()
                 Directory(name: "contents") {
                     Directory(name: "test") {
                         MarkdownFile(

--- a/Tests/ToucanSDKTests/E2ETestSuite.swift
+++ b/Tests/ToucanSDKTests/E2ETestSuite.swift
@@ -265,14 +265,14 @@ struct E2ETestSuite {
     // MARK: - other tests
 
     @Test
-    func context() throws {
+    func customContextViewForAllPipeline() throws {
         let now = Date()
 
         try FileManagerPlayground {
             Mocks.E2E.src(
                 now: now,
                 debugContext: #"""
-                    {{page}}
+                    {{page.description}}
                     """#
             )
         }
@@ -281,18 +281,10 @@ struct E2ETestSuite {
             try Toucan(input: input.path()).generate(now: now)
 
             let output = $1.appendingPathIfPresent("docs")
-            let contextURL = output.appendingPathIfPresent("context/index.html")
-            let context = try String(contentsOf: contextURL)
-
-            #expect(
-                context
-                    .replacingOccurrences(
-                        [
-                            "&quot;": "\""
-                        ]
-                    )
-                    .contains("Context page description")
-            )
+            let htmlURL = output.appendingPathIfPresent("context/index.html")
+            let html = try String(contentsOf: htmlURL)
+            let exp = "Context page description"
+            #expect(html.trimmingCharacters(in: .whitespacesAndNewlines) == exp)
         }
     }
 

--- a/Tests/ToucanSDKTests/E2ETestSuite.swift
+++ b/Tests/ToucanSDKTests/E2ETestSuite.swift
@@ -1148,7 +1148,7 @@ struct E2ETestSuite {
                                 options: [
                                     "contentTypes": [
                                         "test": [
-                                            "template": "test"
+                                            "view": "test"
                                         ]
                                     ]
                                 ]

--- a/Tests/ToucanSDKTests/Files/MustacheFile.swift
+++ b/Tests/ToucanSDKTests/Files/MustacheFile.swift
@@ -12,16 +12,16 @@ import ToucanSerialization
 struct MustacheFile {
     var name: String
     var ext: String
-    var template: String
+    var contents: String
 
     init(
         name: String,
         ext: String = "mustache",
-        template: String
+        contents: String
     ) {
         self.name = name
         self.ext = ext
-        self.template = template
+        self.contents = contents
     }
 }
 
@@ -30,7 +30,7 @@ extension MustacheFile: BuildableItem {
         .file(
             .init(
                 name: name + "." + ext,
-                string: template
+                string: contents
             )
         )
     }

--- a/Tests/ToucanSDKTests/Mocks/Mocks+E2E.swift
+++ b/Tests/ToucanSDKTests/Mocks/Mocks+E2E.swift
@@ -98,34 +98,34 @@ extension Mocks.E2E {
                 Directory(name: "views") {
                     MustacheFile(
                         name: "test",
-                        template: Mocks.Views.page()
+                        contents: Mocks.Views.page()
                     )
                     Directory(name: "docs") {
                         Directory(name: "category") {
                             MustacheFile(
                                 name: "default",
-                                template: Mocks.Views.category()
+                                contents: Mocks.Views.category()
                             )
                         }
                         Directory(name: "guide") {
                             MustacheFile(
                                 name: "default",
-                                template: Mocks.Views.guide()
+                                contents: Mocks.Views.guide()
                             )
                         }
                     }
                     Directory(name: "pages") {
                         MustacheFile(
                             name: "default",
-                            template: Mocks.Views.page()
+                            contents: Mocks.Views.page()
                         )
                         MustacheFile(
                             name: "404",
-                            template: Mocks.Views.notFound()
+                            contents: Mocks.Views.notFound()
                         )
                         MustacheFile(
                             name: "context",
-                            template: Mocks.Views.context(
+                            contents: Mocks.Views.context(
                                 value: debugContext
                             )
                         )
@@ -134,19 +134,19 @@ extension Mocks.E2E {
                         Directory(name: "tag") {
                             MustacheFile(
                                 name: "default",
-                                template: Mocks.Views.tag()
+                                contents: Mocks.Views.tag()
                             )
                         }
                         Directory(name: "post") {
                             MustacheFile(
                                 name: "default",
-                                template: Mocks.Views.post()
+                                contents: Mocks.Views.post()
                             )
                         }
                         Directory(name: "author") {
                             MustacheFile(
                                 name: "default",
-                                template: Mocks.Views.author()
+                                contents: Mocks.Views.author()
                             )
                         }
                     }
@@ -154,43 +154,43 @@ extension Mocks.E2E {
                         Directory(name: "blog") {
                             MustacheFile(
                                 name: "author",
-                                template: Mocks.Views.partialAuthor()
+                                contents: Mocks.Views.partialAuthor()
                             )
                             MustacheFile(
                                 name: "tag",
-                                template: Mocks.Views.partialTag()
+                                contents: Mocks.Views.partialTag()
                             )
                             MustacheFile(
                                 name: "post",
-                                template: Mocks.Views.partialPost()
+                                contents: Mocks.Views.partialPost()
                             )
                         }
                         Directory(name: "docs") {
                             MustacheFile(
                                 name: "category",
-                                template: Mocks.Views.partialCategory()
+                                contents: Mocks.Views.partialCategory()
                             )
                             MustacheFile(
                                 name: "guide",
-                                template: Mocks.Views.partialGuide()
+                                contents: Mocks.Views.partialGuide()
                             )
                         }
                     }
                     MustacheFile(
                         name: "html",
-                        template: Mocks.Views.html()
+                        contents: Mocks.Views.html()
                     )
                     MustacheFile(
                         name: "redirect",
-                        template: Mocks.Views.redirect()
+                        contents: Mocks.Views.redirect()
                     )
                     MustacheFile(
                         name: "rss",
-                        template: Mocks.Views.rss()
+                        contents: Mocks.Views.rss()
                     )
                     MustacheFile(
                         name: "sitemap",
-                        template: Mocks.Views.sitemap()
+                        contents: Mocks.Views.sitemap()
                     )
                 }
             }

--- a/Tests/ToucanSDKTests/Mocks/Mocks+Files.swift
+++ b/Tests/ToucanSDKTests/Mocks/Mocks+Files.swift
@@ -162,14 +162,14 @@ extension File.Mocks {
 
     static func templateRSSView() -> MustacheFile {
         .init(
-            name: "rss.mustache",
+            name: "rss",
             contents: Mocks.Views.rss()
         )
     }
 
     static func templateSitemapView() -> MustacheFile {
         .init(
-            name: "sitemap.mustache",
+            name: "sitemap",
             contents: Mocks.Views.sitemap()
         )
     }

--- a/Tests/ToucanSDKTests/Mocks/Mocks+Files.swift
+++ b/Tests/ToucanSDKTests/Mocks/Mocks+Files.swift
@@ -91,28 +91,28 @@ extension File.Mocks {
     static func template404View() -> MustacheFile {
         .init(
             name: "404",
-            template: Mocks.Views.notFound()
+            contents: Mocks.Views.notFound()
         )
     }
 
     static func templateDefaultView() -> MustacheFile {
         .init(
             name: "default",
-            template: Mocks.Views.page()
+            contents: Mocks.Views.page()
         )
     }
 
     static func templateHomeView() -> MustacheFile {
         .init(
             name: "home",
-            template: Mocks.Views.home()
+            contents: Mocks.Views.home()
         )
     }
 
     static func templateFooterView() -> MustacheFile {
         .init(
             name: "footer",
-            template: """
+            contents: """
                 <footer>
                     <p>This site was generated using <a href="https://www.swift.org/" target="_blank">Swift</a> & <a href="https://github.com/toucansites/toucan" target="_blank">Toucan</a>.</p>
 
@@ -125,7 +125,7 @@ extension File.Mocks {
     static func templateHeaderView() -> MustacheFile {
         .init(
             name: "header",
-            template: """
+            contents: """
                 <header>
                     <a id="logo" href="/">
                         <img
@@ -149,28 +149,28 @@ extension File.Mocks {
     static func templateHTMLView() -> MustacheFile {
         .init(
             name: "html",
-            template: Mocks.Views.html()
+            contents: Mocks.Views.html()
         )
     }
 
     static func templateRedirectView() -> MustacheFile {
         .init(
             name: "redirect",
-            template: Mocks.Views.redirect()
+            contents: Mocks.Views.redirect()
         )
     }
 
     static func templateRSSView() -> MustacheFile {
         .init(
             name: "rss.mustache",
-            template: Mocks.Views.rss()
+            contents: Mocks.Views.rss()
         )
     }
 
     static func templateSitemapView() -> MustacheFile {
         .init(
             name: "sitemap.mustache",
-            template: Mocks.Views.sitemap()
+            contents: Mocks.Views.sitemap()
         )
     }
 

--- a/Tests/ToucanSDKTests/Mocks/Mocks+Pipelines.swift
+++ b/Tests/ToucanSDKTests/Mocks/Mocks+Pipelines.swift
@@ -165,22 +165,22 @@ extension Mocks.Pipelines {
                 options: [
                     "contentTypes": [
                         "page": [
-                            "template": "pages.default"
+                            "view": "pages.default"
                         ],
                         "post": [
-                            "template": "blog.post.default"
+                            "view": "blog.post.default"
                         ],
                         "author": [
-                            "template": "blog.author.default"
+                            "view": "blog.author.default"
                         ],
                         "tag": [
-                            "template": "blog.tag.default"
+                            "view": "blog.tag.default"
                         ],
                         "category": [
-                            "template": "docs.category.default"
+                            "view": "docs.category.default"
                         ],
                         "guide": [
-                            "template": "docs.guide.default"
+                            "view": "docs.guide.default"
                         ],
                     ]
                 ]
@@ -216,7 +216,7 @@ extension Mocks.Pipelines {
                 options: [
                     "contentTypes": [
                         "not-found": [
-                            "template": "pages.404"
+                            "view": "pages.404"
                         ]
                     ]
                 ]
@@ -252,7 +252,7 @@ extension Mocks.Pipelines {
                 options: [
                     "contentTypes": [
                         "redirect": [
-                            "template": "redirect"
+                            "view": "redirect"
                         ]
                     ]
                 ]
@@ -308,7 +308,7 @@ extension Mocks.Pipelines {
                 options: [
                     "contentTypes": [
                         "rss": [
-                            "template": "rss"
+                            "view": "rss"
                         ]
                     ]
                 ]
@@ -391,7 +391,7 @@ extension Mocks.Pipelines {
                 options: [
                     "contentTypes": [
                         "sitemap": [
-                            "template": "sitemap"
+                            "view": "sitemap"
                         ]
                     ]
                 ]

--- a/Tests/ToucanSDKTests/Mocks/Mocks+RawContents.swift
+++ b/Tests/ToucanSDKTests/Mocks/Mocks+RawContents.swift
@@ -104,6 +104,11 @@ extension Mocks.RawContents {
                 frontMatter: [
                     "title": "Context page",
                     "description": "Context page description",
+
+                    "views": [
+                        "*": "pages.context",
+                        "invalid-pipeline": "invalid-view",
+                    ],
                 ],
                 contents: """
                     # Context page

--- a/Tests/ToucanSDKTests/Mocks/Mocks+RawContents.swift
+++ b/Tests/ToucanSDKTests/Mocks/Mocks+RawContents.swift
@@ -104,13 +104,6 @@ extension Mocks.RawContents {
                 frontMatter: [
                     "title": "Context page",
                     "description": "Context page description",
-                    // TODO: pipeline settings
-                    "pipeline": [
-                        "html": [
-                            "view": "pages.context"
-                        ]
-                    ],
-                    "view": "pages.context",
                 ],
                 contents: """
                     # Context page

--- a/Tests/ToucanSDKTests/Mocks/Mocks+RawContents.swift
+++ b/Tests/ToucanSDKTests/Mocks/Mocks+RawContents.swift
@@ -104,7 +104,13 @@ extension Mocks.RawContents {
                 frontMatter: [
                     "title": "Context page",
                     "description": "Context page description",
-                    "template": "pages.context",
+                    // TODO: pipeline settings
+                    "pipeline": [
+                        "html": [
+                            "view": "pages.context"
+                        ]
+                    ],
+                    "view": "pages.context",
                 ],
                 contents: """
                     # Context page


### PR DESCRIPTION
- pipeline engine options: template -> view
- front matter: remove `template` key use views instead:
```yaml
views:
  "*": "custom-view-for-every-pipeline"
  "pipeline-id": "custom-view-for-specific-pipeline"

```
