### PR TITLE
Add repository option to specify source repo

### DIFF
--- a/Sources/toucan-init/Entrypoint.swift
+++ b/Sources/toucan-init/Entrypoint.swift
@@ -36,9 +36,9 @@ struct Entrypoint: AsyncParsableCommand {
     
     @Option(
         name: .shortAndLong,
-        help: "Specifies the repository to download as the starting point. If not specified, a minimal setup will be used."
+        help: "Specifies a URL to a remote zip file containing a demo project to use as the starting point. If not specified, a minimal setup will be used."
     )
-    var repository: String?
+    var demoSourceZipURL: String?
 
     func run() async throws {
         var logger = Logger(label: "toucan")
@@ -52,7 +52,7 @@ struct Entrypoint: AsyncParsableCommand {
         }
 
         do {
-            let sourceUrl = repository.flatMap { URL(string: $0) }
+            let sourceUrl = demoSourceZipURL.flatMap { URL(string: $0) }
             
             let source = Download(
                 sourceURL: sourceUrl ?? minimalSourceURL,
@@ -87,13 +87,5 @@ extension Entrypoint {
             string:
                 "https://github.com/toucansites/minimal-template-demo/archive/refs/heads/main.zip"
         )!
-    }
-
-    var defaultTemplatesURL: URL {
-        BuiltTargetSourceLocations(
-            sourceURL: siteDirectoryURL,
-            config: .defaults
-        )
-        .currentTemplateURL
     }
 }

--- a/Sources/toucan-init/Entrypoint.swift
+++ b/Sources/toucan-init/Entrypoint.swift
@@ -33,10 +33,11 @@ struct Entrypoint: AsyncParsableCommand {
 
     @Option(name: .shortAndLong, help: "The log level to use.")
     var logLevel: Logger.Level = .info
-    
+
     @Option(
         name: .shortAndLong,
-        help: "Specifies a URL to a remote zip file containing a demo project to use as the starting point. If not specified, a minimal setup will be used."
+        help:
+            "Specifies a URL to a remote zip file containing a demo project to use as the starting point. If not specified, a minimal setup will be used."
     )
     var demoSourceZipURL: String?
 
@@ -53,7 +54,7 @@ struct Entrypoint: AsyncParsableCommand {
 
         do {
             let sourceUrl = demoSourceZipURL.flatMap { URL(string: $0) }
-            
+
             let source = Download(
                 sourceURL: sourceUrl ?? minimalSourceURL,
                 targetDirURL: siteDirectoryURL,

--- a/Sources/toucan-init/Entrypoint.swift
+++ b/Sources/toucan-init/Entrypoint.swift
@@ -33,6 +33,12 @@ struct Entrypoint: AsyncParsableCommand {
 
     @Option(name: .shortAndLong, help: "The log level to use.")
     var logLevel: Logger.Level = .info
+    
+    @Option(
+        name: .shortAndLong,
+        help: "Specifies the repository to download as the starting point. If not specified, a minimal setup will be used."
+    )
+    var repository: String?
 
     func run() async throws {
         var logger = Logger(label: "toucan")
@@ -46,8 +52,10 @@ struct Entrypoint: AsyncParsableCommand {
         }
 
         do {
+            let sourceUrl = repository.flatMap { URL(string: $0) }
+            
             let source = Download(
-                sourceURL: minimalSourceURL,
+                sourceURL: sourceUrl ?? minimalSourceURL,
                 targetDirURL: siteDirectoryURL,
                 fileManager: fileManager
             )


### PR DESCRIPTION
Introduces a new --demoSourceZipURL option to allow users to specify a URL as the starting point. If not provided, the minimal setup is used as before.