### PR TITLE
Refactor context and scope keys to enums

### DIFF
--- a/Sources/ToucanSDK/Content/Content+Query.swift
+++ b/Sources/ToucanSDK/Content/Content+Query.swift
@@ -50,7 +50,7 @@ public extension Content {
             rawValue.lastModificationDate
         )
         fields[SystemPropertyKeys.slug.rawValue] = .init(slug.value)
-        fields["iterator"] = .init(isIterator)
+        fields[RootContextKeys.iterator.rawValue] = .init(isIterator)
 
         return fields
     }

--- a/Sources/ToucanSDK/Outputs/ContextBundleToHTMLRenderer.swift
+++ b/Sources/ToucanSDK/Outputs/ContextBundleToHTMLRenderer.swift
@@ -29,7 +29,10 @@ struct ContextBundleToHTMLRenderer {
 
         let engineOptions = pipeline.engine.options
         self.engineContentTypesOptions = engineOptions.dict("contentTypes")
-        self.pipelineViewKey = ["views", pipeline.id].joined(separator: ".")
+        self.pipelineViewKey = [
+            ViewFrontMatterKeys.views.rawValue, pipeline.id,
+        ]
+        .joined(separator: ".")
         self.logger = logger
     }
 
@@ -46,8 +49,12 @@ struct ContextBundleToHTMLRenderer {
             contextBundle.content.type.id
         )
         let frontMatter = contextBundle.content.rawValue.markdown.frontMatter
-        let contentTypeView = contentTypeOptions.string("view")
-        let genericContentView = frontMatter.string("views.*")
+        let contentTypeView = contentTypeOptions.string(
+            ViewFrontMatterKeys.view.rawValue
+        )
+        let genericContentView = frontMatter.string(
+            ViewFrontMatterKeys.any.rawValue
+        )
         let contentView = frontMatter.string(pipelineViewKey)
         let viewId = contentView ?? genericContentView ?? contentTypeView
 

--- a/Sources/ToucanSDK/Renderers/BuildTargetSourceRenderer.swift
+++ b/Sources/ToucanSDK/Renderers/BuildTargetSourceRenderer.swift
@@ -192,13 +192,14 @@ public struct BuildTargetSourceRenderer {
                         pipeline: pipeline,
                         dateFormatter: dateFormatter,
                         now: now,
-                        scopeKey: query.scope ?? "list"
+                        scopeKey: query.scope
+                            ?? Pipeline.Scope.Keys.list.rawValue
                     )
                 }
             )
         }
         return [
-            "context": .init(rawContext)
+            RootContextKeys.context.rawValue: .init(rawContext)
         ]
     }
 
@@ -219,17 +220,18 @@ public struct BuildTargetSourceRenderer {
                 pipeline: pipeline,
                 dateFormatter: dateFormatter,
                 now: now,
-                scopeKey: iteratorInfo.scope ?? "list"
+                scopeKey: iteratorInfo.scope
+                    ?? Pipeline.Scope.Keys.list.rawValue
             )
         }
         return [
-            "iterator": .init(
+            RootContextKeys.iterator.rawValue: .init(
                 [
-                    "total": .init(iteratorInfo.total),
-                    "limit": .init(iteratorInfo.limit),
-                    "current": .init(iteratorInfo.current),
-                    "items": .init(itemContext),
-                    "links": .init(iteratorInfo.links),
+                    IteratorKeys.total.rawValue: .init(iteratorInfo.total),
+                    IteratorKeys.limit.rawValue: .init(iteratorInfo.limit),
+                    IteratorKeys.current.rawValue: .init(iteratorInfo.current),
+                    IteratorKeys.items.rawValue: .init(itemContext),
+                    IteratorKeys.links.rawValue: .init(iteratorInfo.links),
                 ] as [String: AnyCodable]
             )
         ]
@@ -249,7 +251,7 @@ public struct BuildTargetSourceRenderer {
             pipeline: pipeline,
             dateFormatter: dateFormatter,
             now: now,
-            scopeKey: "detail"
+            scopeKey: Pipeline.Scope.Keys.detail.rawValue
         )
 
         let iteratorContext = getIteratorContext(
@@ -261,7 +263,7 @@ public struct BuildTargetSourceRenderer {
         )
 
         let context: [String: AnyCodable] = [
-            "page": .init(pageContext)
+            RootContextKeys.page.rawValue: .init(pageContext)
         ]
         .recursivelyMerged(with: iteratorContext)
         .recursivelyMerged(with: pipelineContext)
@@ -378,7 +380,7 @@ public struct BuildTargetSourceRenderer {
             result[SystemPropertyKeys.lastUpdate.rawValue] = .init(
                 dateFormatter.format(content.rawValue.lastModificationDate)
             )
-            result["permalink"] = .init(
+            result[PageContextKeys.permalink.rawValue] = .init(
                 content.slug.permalink(baseURL: baseURL())
             )
         }
@@ -447,10 +449,10 @@ public struct BuildTargetSourceRenderer {
                 baseURL: baseURL()
             )
 
-            result["contents"] = [
-                "html": contents.html,
-                "readingTime": contents.readingTime,
-                "outline": contents.outline,
+            result[PageContextKeys.contents.rawValue] = [
+                PageContentsKeys.html.rawValue: contents.html,
+                PageContentsKeys.readingTime.rawValue: contents.readingTime,
+                PageContentsKeys.outline.rawValue: contents.outline,
             ]
         }
 
@@ -484,7 +486,7 @@ public struct BuildTargetSourceRenderer {
                         pipeline: pipeline,
                         dateFormatter: dateFormatter,
                         now: now,
-                        scopeKey: "reference",
+                        scopeKey: Pipeline.Scope.Keys.reference.rawValue,
                         allowSubQueries: false
                     )
                 }
@@ -518,7 +520,8 @@ public struct BuildTargetSourceRenderer {
                             pipeline: pipeline,
                             dateFormatter: dateFormatter,
                             now: now,
-                            scopeKey: query.scope ?? "list",
+                            scopeKey: query.scope
+                                ?? Pipeline.Scope.Keys.list.rawValue,
                             allowSubQueries: false
                         )
                     }
@@ -545,7 +548,8 @@ public struct BuildTargetSourceRenderer {
                             result["slug"]?.stringValue() ?? "nil"
                         ),
                         "permalink": .string(
-                            result["permalink"]?.stringValue() ?? "nil"
+                            result[PageContextKeys.permalink.rawValue]?
+                                .stringValue() ?? "nil"
                         ),
                     ]
                 ),
@@ -586,8 +590,8 @@ public struct BuildTargetSourceRenderer {
 
         // TODO: This should be in a .toucaninfo file or similar
         let globalContext: [String: AnyCodable] = [
-            "baseUrl": .init(baseURL()),
-            "generator": .init(generatorInfo),
+            GlobalContextKeys.baseUrl.rawValue: .init(baseURL()),
+            GlobalContextKeys.generator.rawValue: .init(generatorInfo),
         ]
 
         let contentTypeResolver = ContentTypeResolver(
@@ -658,8 +662,12 @@ public struct BuildTargetSourceRenderer {
                         SystemPropertyKeys.lastUpdate.rawValue: .init(
                             dateFormatter.format(lastUpdate)
                         ),
-                        "generation": .init(dateFormatter.format(now)),
-                        "site": .init(buildTargetSource.settings.values),
+                        GlobalContextKeys.generation.rawValue: .init(
+                            dateFormatter.format(now)
+                        ),
+                        GlobalContextKeys.site.rawValue: .init(
+                            buildTargetSource.settings.values
+                        ),
                     ]
                 ),
                 pipeline: pipeline,

--- a/Sources/ToucanSDK/Utilities/ContextKeys.swift
+++ b/Sources/ToucanSDK/Utilities/ContextKeys.swift
@@ -1,0 +1,50 @@
+//
+//  ContextKeys.swift
+//  Toucan
+//
+//  Created by Codex on 2025-08-28.
+//
+
+/// Root-level keys used in the rendered context bundles.
+public enum RootContextKeys: String, CaseIterable {
+    case page
+    case iterator
+    case context
+}
+
+/// Standard keys included in the page context dictionary.
+public enum PageContextKeys: String, CaseIterable {
+    case contents
+    case permalink
+}
+
+/// Keys for the `page.contents` dictionary.
+public enum PageContentsKeys: String, CaseIterable {
+    case html
+    case readingTime
+    case outline
+}
+
+/// Keys for iterator metadata inside the context bundle.
+public enum IteratorKeys: String, CaseIterable {
+    case total
+    case limit
+    case current
+    case items
+    case links
+}
+
+/// Global keys merged into the rendering context.
+public enum GlobalContextKeys: String, CaseIterable {
+    case baseUrl
+    case generator
+    case generation
+    case site
+}
+
+/// Front matter keys related to view resolution.
+public enum ViewFrontMatterKeys: String, CaseIterable {
+    case view
+    case views
+    case any = "views.*"
+}

--- a/Sources/ToucanSDK/Utilities/ContextKeys.swift
+++ b/Sources/ToucanSDK/Utilities/ContextKeys.swift
@@ -2,7 +2,7 @@
 //  ContextKeys.swift
 //  Toucan
 //
-//  Created by Codex on 2025-08-28.
+//  Created by Viasz-Kádi Ferenc on 2025. 09. 04..
 //
 
 /// Root-level keys used in the rendered context bundles.

--- a/Sources/ToucanSource/Objects/Pipeline/Pipeline+Scope+Context.swift
+++ b/Sources/ToucanSource/Objects/Pipeline/Pipeline+Scope+Context.swift
@@ -63,14 +63,14 @@ public extension Pipeline.Scope {
         /// Returns the mapping of context options to their string names.
         private var allOptions: [(Context, String)] {
             [
-                (.userDefined, "userDefined"),
-                (.properties, "properties"),
-                (.contents, "contents"),
-                (.relations, "relations"),
-                (.queries, "queries"),
-                (.reference, "reference"),
-                (.list, "list"),
-                (.detail, "detail"),
+                (.userDefined, Keys.userDefined.rawValue),
+                (.properties, Keys.properties.rawValue),
+                (.contents, Keys.contents.rawValue),
+                (.relations, Keys.relations.rawValue),
+                (.queries, Keys.queries.rawValue),
+                (.reference, Keys.reference.rawValue),
+                (.list, Keys.list.rawValue),
+                (.detail, Keys.detail.rawValue),
             ]
         }
 
@@ -91,21 +91,21 @@ public extension Pipeline.Scope {
         /// - Parameter stringValue: The string representation of the context.
         public init(stringValue: String) {
             switch stringValue.lowercased() {
-            case "userdefined":
+            case Keys.userDefined.rawValue:
                 self = .userDefined
-            case "properties":
+            case Keys.properties.rawValue:
                 self = .properties
-            case "contents":
+            case Keys.contents.rawValue:
                 self = .contents
-            case "relations":
+            case Keys.relations.rawValue:
                 self = .relations
-            case "queries":
+            case Keys.queries.rawValue:
                 self = .queries
-            case "reference":
+            case Keys.reference.rawValue:
                 self = .reference
-            case "list":
+            case Keys.list.rawValue:
                 self = .list
-            case "detail":
+            case Keys.detail.rawValue:
                 self = .detail
             default:
                 self = []
@@ -162,5 +162,20 @@ public extension Pipeline.Scope {
                 try container.encode(parts)
             }
         }
+    }
+}
+
+extension Pipeline.Scope.Context {
+
+    /// String keys used to identify pipeline scope contexts.
+    public enum Keys: String, CaseIterable {
+        case userDefined
+        case properties
+        case contents
+        case relations
+        case queries
+        case reference
+        case list
+        case detail
     }
 }

--- a/Sources/ToucanSource/Objects/Pipeline/Pipeline+Scope.swift
+++ b/Sources/ToucanSource/Objects/Pipeline/Pipeline+Scope.swift
@@ -15,6 +15,14 @@ public extension Pipeline {
             case fields
         }
 
+        /// String keys used to identify pipeline scopes.
+        public enum Keys: String, CaseIterable {
+            case reference
+            case list
+            case detail
+            case wildcard = "*"
+        }
+
         /// A scope for rendering lightweight summaries or IDs for use in references.
         public static var reference: Scope {
             .init(context: .reference)
@@ -33,16 +41,16 @@ public extension Pipeline {
         /// A standard mapping of common context names to their default scopes.
         public static var standard: [String: Scope] {
             [
-                "reference": reference,
-                "list": list,
-                "detail": detail,
+                Keys.reference.rawValue: reference,
+                Keys.list.rawValue: list,
+                Keys.detail.rawValue: detail,
             ]
         }
 
         /// The default fallback scope set, applied to all content types via the `*` wildcard.
         public static var `default`: [String: [String: Scope]] {
             [
-                "*": standard
+                Keys.wildcard.rawValue: standard
             ]
         }
 

--- a/Sources/ToucanSource/Objects/Pipeline/Pipeline.swift
+++ b/Sources/ToucanSource/Objects/Pipeline/Pipeline.swift
@@ -176,7 +176,7 @@ public struct Pipeline: Codable {
         if let scopes = scopes[contentType] {
             return scopes
         }
-        return scopes["*"] ?? [:]
+        return scopes[Scope.Keys.wildcard.rawValue] ?? [:]
     }
 
     /// Returns a single scope for a given content type and scope key (e.g., `"list"`, `"detail"`).

--- a/Tests/ToucanSDKTests/BuildTargetSource/BuildTargetSourceRendererTestSuite.swift
+++ b/Tests/ToucanSDKTests/BuildTargetSource/BuildTargetSourceRendererTestSuite.swift
@@ -74,7 +74,7 @@ struct BuildTargetSourceRendererTestSuite {
                 queries: [
                     "posts": .init(
                         contentType: "post",
-                        scope: "list",
+                        scope: Pipeline.Scope.Keys.list.rawValue,
                         orderBy: [
                             .init(
                                 key: "publication",

--- a/Tests/ToucanSDKTests/Content/ContentResolverTestSuite.swift
+++ b/Tests/ToucanSDKTests/Content/ContentResolverTestSuite.swift
@@ -1161,7 +1161,7 @@ struct ContentResolverTestSuite {
         let query = Query(
             contentType: "page",
             filter: .field(
-                key: "iterator",
+                key: RootContextKeys.iterator.rawValue,
                 operator: .equals,
                 value: true
             )

--- a/Tests/ToucanSDKTests/E2ETestSuite.swift
+++ b/Tests/ToucanSDKTests/E2ETestSuite.swift
@@ -1028,7 +1028,8 @@ struct E2ETestSuite {
                                 options: [
                                     "contentTypes": [
                                         "test": [
-                                            "view": "foo"
+                                            ViewFrontMatterKeys.view.rawValue:
+                                                "foo"
                                         ]
                                     ]
                                 ]
@@ -1132,7 +1133,8 @@ struct E2ETestSuite {
                                 options: [
                                     "contentTypes": [
                                         "test": [
-                                            "view": "test"
+                                            ViewFrontMatterKeys.view.rawValue:
+                                                "test"
                                         ]
                                     ]
                                 ]
@@ -1280,7 +1282,7 @@ struct E2ETestSuite {
                                             "slug"
                                         ]
                                     ),
-                                    "detail": .init(
+                                    Pipeline.Scope.Keys.list.rawValue: .init(
                                         context: .detail,
                                         fields: [
                                             "title",

--- a/Tests/ToucanSDKTests/Mocks/Mocks+ContentTypes.swift
+++ b/Tests/ToucanSDKTests/Mocks/Mocks+ContentTypes.swift
@@ -73,7 +73,7 @@ extension Mocks.ContentTypes {
             queries: [
                 "posts": .init(
                     contentType: "post",
-                    scope: "list",
+                    scope: Pipeline.Scope.Keys.list.rawValue,
                     filter: .field(
                         key: "authors",
                         operator: .contains,
@@ -115,7 +115,7 @@ extension Mocks.ContentTypes {
             queries: [
                 "posts": .init(
                     contentType: "post",
-                    scope: "list",
+                    scope: Pipeline.Scope.Keys.list.rawValue,
                     filter: .field(
                         key: "tags",
                         operator: .contains,
@@ -232,7 +232,7 @@ extension Mocks.ContentTypes {
                 ),
                 "related": .init(
                     contentType: "post",
-                    scope: "list",
+                    scope: Pipeline.Scope.Keys.list.rawValue,
                     limit: 4,
                     filter: .and(
                         [
@@ -253,7 +253,7 @@ extension Mocks.ContentTypes {
 
                 "similar": .init(
                     contentType: "post",
-                    scope: "list",
+                    scope: Pipeline.Scope.Keys.list.rawValue,
                     limit: 4,
                     filter: .and(
                         [
@@ -305,7 +305,7 @@ extension Mocks.ContentTypes {
             queries: [
                 "guides": .init(
                     contentType: "guide",
-                    scope: "list",
+                    scope: Pipeline.Scope.Keys.list.rawValue,
                     filter: .field(
                         key: "category",
                         operator: .equals,

--- a/Tests/ToucanSDKTests/Mocks/Mocks+Pipelines.swift
+++ b/Tests/ToucanSDKTests/Mocks/Mocks+Pipelines.swift
@@ -6,6 +6,7 @@
 //
 
 import ToucanSource
+import ToucanSDK
 
 extension Mocks.Pipelines {
     static func html() -> Pipeline {
@@ -16,7 +17,7 @@ extension Mocks.Pipelines {
             queries: [
                 "featured": .init(
                     contentType: "post",
-                    scope: "list",
+                    scope: Pipeline.Scope.Keys.list.rawValue,
                     filter: .field(
                         key: "featured",
                         operator: .equals,
@@ -165,22 +166,27 @@ extension Mocks.Pipelines {
                 options: [
                     "contentTypes": [
                         "page": [
-                            "view": "pages.default"
+                            ViewFrontMatterKeys.view.rawValue: "pages.default"
                         ],
                         "post": [
-                            "view": "blog.post.default"
+                            ViewFrontMatterKeys.view.rawValue:
+                                "blog.post.default"
                         ],
                         "author": [
-                            "view": "blog.author.default"
+                            ViewFrontMatterKeys.view.rawValue:
+                                "blog.author.default"
                         ],
                         "tag": [
-                            "view": "blog.tag.default"
+                            ViewFrontMatterKeys.view.rawValue:
+                                "blog.tag.default"
                         ],
                         "category": [
-                            "view": "docs.category.default"
+                            ViewFrontMatterKeys.view.rawValue:
+                                "docs.category.default"
                         ],
                         "guide": [
-                            "view": "docs.guide.default"
+                            ViewFrontMatterKeys.view.rawValue:
+                                "docs.guide.default"
                         ],
                     ]
                 ]
@@ -216,7 +222,7 @@ extension Mocks.Pipelines {
                 options: [
                     "contentTypes": [
                         "not-found": [
-                            "view": "pages.404"
+                            ViewFrontMatterKeys.view.rawValue: "pages.404"
                         ]
                     ]
                 ]
@@ -252,7 +258,7 @@ extension Mocks.Pipelines {
                 options: [
                     "contentTypes": [
                         "redirect": [
-                            "view": "redirect"
+                            ViewFrontMatterKeys.view.rawValue: "redirect"
                         ]
                     ]
                 ]
@@ -273,7 +279,7 @@ extension Mocks.Pipelines {
             queries: [
                 "posts": .init(
                     contentType: "post",
-                    scope: "list",
+                    scope: Pipeline.Scope.Keys.list.rawValue,
                     orderBy: [
                         .init(
                             key: SystemPropertyKeys.lastUpdate.rawValue,
@@ -311,7 +317,7 @@ extension Mocks.Pipelines {
                 options: [
                     "contentTypes": [
                         "rss": [
-                            "view": "rss"
+                            ViewFrontMatterKeys.view.rawValue: "rss"
                         ]
                     ]
                 ]
@@ -332,7 +338,7 @@ extension Mocks.Pipelines {
             queries: [
                 "pages": .init(
                     contentType: "page",
-                    scope: "list",
+                    scope: Pipeline.Scope.Keys.list.rawValue,
                     orderBy: [
                         .init(
                             key: SystemPropertyKeys.lastUpdate.rawValue,
@@ -343,7 +349,7 @@ extension Mocks.Pipelines {
                 ),
                 "posts": .init(
                     contentType: "post",
-                    scope: "list",
+                    scope: Pipeline.Scope.Keys.list.rawValue,
                     orderBy: [
                         .init(
                             key: SystemPropertyKeys.lastUpdate.rawValue,
@@ -353,7 +359,7 @@ extension Mocks.Pipelines {
                 ),
                 "authors": .init(
                     contentType: "author",
-                    scope: "list",
+                    scope: Pipeline.Scope.Keys.list.rawValue,
                     orderBy: [
                         .init(
                             key: SystemPropertyKeys.lastUpdate.rawValue,
@@ -363,7 +369,7 @@ extension Mocks.Pipelines {
                 ),
                 "tags": .init(
                     contentType: "tag",
-                    scope: "list",
+                    scope: Pipeline.Scope.Keys.list.rawValue,
                     orderBy: [
                         .init(
                             key: SystemPropertyKeys.lastUpdate.rawValue,
@@ -407,7 +413,7 @@ extension Mocks.Pipelines {
                 options: [
                     "contentTypes": [
                         "sitemap": [
-                            "view": "sitemap"
+                            ViewFrontMatterKeys.view.rawValue: "sitemap"
                         ]
                     ]
                 ]
@@ -428,7 +434,7 @@ extension Mocks.Pipelines {
             queries: [
                 "posts": .init(
                     contentType: "post",
-                    scope: "list",
+                    scope: Pipeline.Scope.Keys.list.rawValue,
                     orderBy: [
                         .init(
                             key: "publication",

--- a/Tests/ToucanSDKTests/Mocks/Mocks+RawContents.swift
+++ b/Tests/ToucanSDKTests/Mocks/Mocks+RawContents.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import ToucanSource
+import ToucanSDK
 
 extension Mocks.RawContents {
     static func homePage(
@@ -105,7 +106,7 @@ extension Mocks.RawContents {
                     "title": "Context page",
                     "description": "Context page description",
 
-                    "views": [
+                    ViewFrontMatterKeys.views.rawValue: [
                         "*": "pages.context",
                         "invalid-pipeline": "invalid-view",
                     ],

--- a/Tests/ToucanSDKTests/Utilities/UnboxingTestSuite.swift
+++ b/Tests/ToucanSDKTests/Utilities/UnboxingTestSuite.swift
@@ -18,7 +18,7 @@ struct UnboxingTests {
     @Test
     func unboxing() throws {
         let value: [String: AnyCodable] = [
-            "context": [
+            RootContextKeys.context.rawValue: [
                 "posts": [
                     [
                         "publication": AnyCodable(
@@ -51,9 +51,11 @@ struct UnboxingTests {
                             "Migration guide for Toucan Beta 3: covering changes to content structure, template changes and rendering features."
                         ),
                         "featured": AnyCodable(true),
-                        "contents": AnyCodable([
-                            "readingTime": AnyCodable(2),
-                            "outline": AnyCodable([
+                        PageContextKeys.contents.rawValue: AnyCodable([
+                            PageContentsKeys.readingTime.rawValue: AnyCodable(
+                                2
+                            ),
+                            PageContentsKeys.outline.rawValue: AnyCodable([
                                 AnyCodable(
                                     Optional(
                                         Outline(
@@ -99,16 +101,22 @@ struct UnboxingTests {
                                     )
                                 ),
                             ]),
-                            "html": AnyCodable("<p></p>"),
+                            PageContentsKeys.html.rawValue: AnyCodable(
+                                "<p></p>"
+                            ),
                         ]),
                         "authors": AnyCodable([
                             [
-                                "contents": AnyCodable([
-                                    "outline": AnyCodable([]),
-                                    "html": AnyCodable(""),
-                                    "readingTime": AnyCodable(1),
+                                PageContextKeys.contents.rawValue: AnyCodable([
+                                    PageContentsKeys.outline.rawValue:
+                                        AnyCodable([]),
+                                    PageContentsKeys.html.rawValue: AnyCodable(
+                                        ""
+                                    ),
+                                    PageContentsKeys.readingTime.rawValue:
+                                        AnyCodable(1),
                                 ]),
-                                "permalink": AnyCodable(
+                                PageContextKeys.permalink.rawValue: AnyCodable(
                                     "https://toucansites.com/authors/gabor-lengyel/"
                                 ),
                                 "description": AnyCodable(
@@ -165,7 +173,7 @@ struct UnboxingTests {
                             Optional(Slug("beta-3-migration-guide"))
                         ),
                         "title": AnyCodable("Beta 3 migration guide"),
-                        "permalink": AnyCodable(
+                        PageContextKeys.permalink.rawValue: AnyCodable(
                             "https://toucansites.com/beta-3-migration-guide/"
                         ),
                     ]

--- a/Tests/ToucanSourceTests/Objects/Pipeline/PipelineScopeContextTestSuite.swift
+++ b/Tests/ToucanSourceTests/Objects/Pipeline/PipelineScopeContextTestSuite.swift
@@ -25,7 +25,8 @@ struct PipelineScopeContextTestSuite {
 
     @Test
     func decodingMultipleValues() throws {
-        let json = #"["contents", "queries"]"#
+        let json =
+            #"["\#(Pipeline.Scope.Context.Keys.contents.rawValue)", "\#(Pipeline.Scope.Context.Keys.queries.rawValue)"]"#
         let data = json.data(using: .utf8)!
         let result = try ToucanJSONDecoder()
             .decode(Pipeline.Scope.Context.self, from: data)
@@ -39,7 +40,7 @@ struct PipelineScopeContextTestSuite {
 
     @Test
     func decodingSingleValue() throws {
-        let json = #""properties""#
+        let json = #""\#(Pipeline.Scope.Context.Keys.properties.rawValue)""#
         let data = json.data(using: .utf8)!
         let result = try ToucanJSONDecoder()
             .decode(Pipeline.Scope.Context.self, from: data)
@@ -53,7 +54,7 @@ struct PipelineScopeContextTestSuite {
 
     @Test
     func decodingSingleAllValue() throws {
-        let json = #""detail""#
+        let json = #""\#(Pipeline.Scope.Context.Keys.detail.rawValue)""#
         let data = json.data(using: .utf8)!
         let result = try ToucanJSONDecoder()
             .decode(Pipeline.Scope.Context.self, from: data)

--- a/Tests/ToucanSourceTests/Objects/Pipeline/PipelineTestSuite.swift
+++ b/Tests/ToucanSourceTests/Objects/Pipeline/PipelineTestSuite.swift
@@ -151,15 +151,25 @@ struct PipelineTestSuite {
 
         #expect(result.contentTypes.include.isEmpty)
         #expect(result.engine.id == "test")
-        let defaultScope = try #require(result.scopes["*"])
-        let defaultReferenceScope = try #require(defaultScope["reference"])
-        let defaultListScope = try #require(defaultScope["list"])
-        let defaultDetailScope = try #require(defaultScope["detail"])
+        let defaultScope = try #require(
+            result.scopes[Pipeline.Scope.Keys.wildcard.rawValue]
+        )
+        let defaultReferenceScope = try #require(
+            defaultScope[Pipeline.Scope.Context.Keys.reference.rawValue]
+        )
+        let defaultListScope = try #require(
+            defaultScope[Pipeline.Scope.Context.Keys.list.rawValue]
+        )
+        let defaultDetailScope = try #require(
+            defaultScope[Pipeline.Scope.Context.Keys.detail.rawValue]
+        )
         #expect(defaultReferenceScope.context == .reference)
         #expect(defaultListScope.context == .list)
         #expect(defaultDetailScope.context == .detail)
         let postScope = try #require(result.scopes["post"])
-        let postListScope = try #require(postScope["list"])
+        let postListScope = try #require(
+            postScope[Pipeline.Scope.Keys.list.rawValue]
+        )
         #expect(postListScope.context == .detail)
     }
 

--- a/Tests/ToucanSourceTests/Objects/Query/QueryTestSuite.swift
+++ b/Tests/ToucanSourceTests/Objects/Query/QueryTestSuite.swift
@@ -82,7 +82,7 @@ struct QueryTestSuite {
         )
 
         #expect(result.contentType == "post")
-        #expect(result.scope == "list")
+        #expect(result.scope == Pipeline.Scope.Keys.list.rawValue)
         #expect(result.limit == 1)
         #expect(result.offset == 0)
 


### PR DESCRIPTION
Introduced strongly-typed enums for context, page, iterator, global, and view keys. Replaced hardcoded string keys throughout the codebase and tests with enum raw values. Updated pipeline scope and context handling to use new enum-based keys, and adjusted all usages in rendering, querying, and test mocks accordingly.