### PR TITLE
Update current generator version to v1.0.0-rc.1

### DIFF
--- a/Sources/ToucanCore/GeneratorInfo.swift
+++ b/Sources/ToucanCore/GeneratorInfo.swift
@@ -12,7 +12,7 @@ public extension GeneratorInfo {
 
     /// Returns the most current version of the generator.
     static var current: Self {
-        .v1_0_0_beta_6
+        .v1_0_0_rc_1
     }
 }
 


### PR DESCRIPTION
Changed the current generator version from v1.0.0-beta.6 to v1.0.0-rc.1 to reflect the latest release candidate.