### PR TITLE
fix git commit hash in CI build, create new PR for formula change

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -38,7 +38,9 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
       - name: Import certificates
         uses: apple-actions/import-codesign-certs@v3
@@ -80,12 +82,24 @@ jobs:
 
       - name: Install Swift 6.1.2
         run: |
-          curl -L https://download.swift.org/swift-6.1.2-release/xcode/swift-6.1.2-RELEASE/swift-6.1.2-RELEASE-osx.pkg -o swift.pkg
-          sudo installer -pkg swift.pkg -target /
-          export TOOLCHAIN_PATH="/Library/Developer/Toolchains/swift-6.1.2-RELEASE.xctoolchain/usr/bin"
+          curl -L https://download.swift.org/swift-6.1.2-release/xcode/swift-6.1.2-RELEASE/swift-6.1.2-RELEASE-osx.pkg -o /tmp/swift.pkg
+          sudo installer -pkg /tmp/swift.pkg -target /
+          TOOLCHAIN_PATH="/Library/Developer/Toolchains/swift-6.1.2-RELEASE.xctoolchain/usr/bin"
           echo "$TOOLCHAIN_PATH" >> $GITHUB_PATH
           export PATH="$TOOLCHAIN_PATH:$PATH"
           swift --version
+
+      - name: Check for uncommitted changes
+        run: |
+          git_status=$(git status --porcelain)
+          
+          if [[ -n "$git_status" ]]; then
+            echo "❌ Uncommitted changes detected:"
+            echo "$git_status"
+            exit 1
+          else
+            echo "✅ Working directory is clean. No uncommitted changes."
+          fi
 
       - name: Build Swift binaries for arm64 and x86_64
         if: inputs.run_pkg

--- a/.github/workflows/pr-for-formula.yml
+++ b/.github/workflows/pr-for-formula.yml
@@ -87,10 +87,13 @@ jobs:
           end
           EOF
 
-      - name: Commit and Push
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add Formula/${{ inputs.formulafile }}
-          git commit -m "Update formula to version $VERSION" || echo "No changes to commit"
-          git push
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.HOMEBREW_TAP_PAT }}
+          commit-message: "Update formula to version ${{ env.VERSION }}"
+          branch: feature/update-formula-${{ env.VERSION }}
+          base: main
+          title: "Update Homebrew formula to ${{ env.VERSION }}"
+          body: |
+            This PR updates the Homebrew formula to version `${{ env.VERSION }}`.

--- a/.github/workflows/tag_actions.yml
+++ b/.github/workflows/tag_actions.yml
@@ -44,10 +44,10 @@ jobs:
       run_dmg: false
     secrets: inherit
 
-  push_formula:
-    name: Push Homebrew Formula
+  pr_for_formula:
+    name: Create a PR for Homebrew Formula
     needs: [prepare, linux, macos]
-    uses: ./.github/workflows/push-formula.yml
+    uses: ./.github/workflows/pr-for-formula.yml
     with:
       version: ${{ needs.prepare.outputs.version }}
       baseurl: https://github.com/toucansites/toucan/releases/download/${{ github.ref_name }}


### PR DESCRIPTION
- swift 6.1.2 is not downloaded into the working directory, so the swift.pkg file will not appear as an uncommitted file
- add an extra step to check for uncommitted files, before builds
- the formula change cannot be pushed directly to main due to branch protection rules, so a new pull request is created instead