### PR TITLE
Fix watch command issues

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2ade195bfb935ebe628d2d585ec01be86efdb47689341024c1e359d5bd4c1f07",
+  "originHash" : "8884d941f28d898f32457bdb5efc31adc58bb68b74589dc8dd3e152fac0371e5",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -17,6 +17,15 @@
       "state" : {
         "revision" : "89a7485d5564aafd77d846fe4366f7e67d6b4b9b",
         "version" : "0.4.0"
+      }
+    },
+    {
+      "identity" : "filemonitor",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/toucansites/FileMonitor",
+      "state" : {
+        "revision" : "082b744b35a2f3d53e19bc1925d358590761551f",
+        "version" : "0.1.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2d5458f3c9c6e561d027f8025ea81c5093e88e599725171181f5ccb1c8761a52",
+  "originHash" : "2ade195bfb935ebe628d2d585ec01be86efdb47689341024c1e359d5bd4c1f07",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -17,15 +17,6 @@
       "state" : {
         "revision" : "89a7485d5564aafd77d846fe4366f7e67d6b4b9b",
         "version" : "0.4.0"
-      }
-    },
-    {
-      "identity" : "filemonitor",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/aus-der-Technik/FileMonitor",
-      "state" : {
-        "revision" : "ef22f1487d07fbff0a7a5f743d42611bfd03b5e8",
-        "version" : "1.2.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -72,10 +72,9 @@ let package = Package(
             from: "2.8.0"
         ),
         .package(  
-            path: "../FileMonitor"
-//            url: "https://github.com/toucansites/FileMonitor",
-//            branch: "main"
-//            from: "1.2.0"
+//            path: "../FileMonitor"
+            url: "https://github.com/toucansites/FileMonitor",
+            from: "0.1.0"
         ),
         .package(
             url: "https://github.com/Zollerboy1/SwiftCommand",

--- a/Package.swift
+++ b/Package.swift
@@ -71,9 +71,11 @@ let package = Package(
             url: "https://github.com/scinfu/SwiftSoup",
             from: "2.8.0"
         ),
-        .package(
-            url: "https://github.com/aus-der-Technik/FileMonitor",
-            from: "1.2.0"
+        .package(  
+            path: "../FileMonitor"
+//            url: "https://github.com/toucansites/FileMonitor",
+//            branch: "main"
+//            from: "1.2.0"
         ),
         .package(
             url: "https://github.com/Zollerboy1/SwiftCommand",

--- a/Sources/ToucanMarkdown/Markdown/HTMLVisitor.swift
+++ b/Sources/ToucanMarkdown/Markdown/HTMLVisitor.swift
@@ -413,6 +413,7 @@ struct HTMLVisitor: MarkupVisitor {
     mutating func visitBlockDirective(
         _ blockDirective: BlockDirective
     ) -> Result {
+
         var parseErrors = [DirectiveArgumentText.ParseError]()
         var arguments: [DirectiveArgument] = []
         let blockName = blockDirective.name.lowercased()
@@ -421,21 +422,38 @@ struct HTMLVisitor: MarkupVisitor {
                 parseErrors: &parseErrors
             )
         }
-        guard parseErrors.isEmpty else {
-            let errors =
-                parseErrors
-                .map { String(describing: $0) }
-                .joined(separator: ", ")
-            logger.warning("\(errors)")
-            return ""
-        }
 
         let block = customBlockDirectives.first {
             $0.name.lowercased() == blockName.lowercased()
         }
         guard let block else {
             logger.warning(
-                "Unrecognized block directive: `\(blockName)`"
+                "Unrecognized block directive: `\(blockName)`",
+                metadata: [
+                    "name": .string(blockName),
+                ]
+            )
+            return ""
+        }
+        
+        guard parseErrors.isEmpty else {
+            let errors = parseErrors.map { error -> String in
+                    switch error {
+                    case let .duplicateArgument(name, _, _):
+                        return "Duplicate argument: `\(name)`."
+                    case let .missingExpectedCharacter(char, _):
+                        return "Misisng expected character: `\(char)`."
+                    case let .unexpectedCharacter(char, _):
+                        return "Unexpected character: `\(char)`."
+                    }
+                }
+                .joined(separator: ", ")
+
+            logger.warning(
+                "\(errors)",
+                metadata: [
+                    "name": .string(blockName),
+                ]
             )
             return ""
         }
@@ -448,7 +466,10 @@ struct HTMLVisitor: MarkupVisitor {
                 }
                 else {
                     logger.warning(
-                        "Parameter `\(p.label)` for `\(block.name)` is required."
+                        "Parameter `\(p.label)` for `\(block.name)` is required.",
+                        metadata: [
+                            "name": .string(blockName),
+                        ]
                     )
                 }
             }
@@ -468,7 +489,10 @@ struct HTMLVisitor: MarkupVisitor {
                 p.name.lowercased() == parent.lowercased()
             else {
                 logger.warning(
-                    "Block directive `\(block.name)` requires parent block `\(parent)`"
+                    "Block directive `\(block.name)` requires parent block `\(parent)`",
+                    metadata: [
+                        "name": .string(blockName),
+                    ]
                 )
                 return ""
             }

--- a/Sources/ToucanMarkdown/Markdown/HTMLVisitor.swift
+++ b/Sources/ToucanMarkdown/Markdown/HTMLVisitor.swift
@@ -430,14 +430,15 @@ struct HTMLVisitor: MarkupVisitor {
             logger.warning(
                 "Unrecognized block directive: `\(blockName)`",
                 metadata: [
-                    "name": .string(blockName),
+                    "name": .string(blockName)
                 ]
             )
             return ""
         }
-        
+
         guard parseErrors.isEmpty else {
-            let errors = parseErrors.map { error -> String in
+            let errors =
+                parseErrors.map { error -> String in
                     switch error {
                     case let .duplicateArgument(name, _, _):
                         return "Duplicate argument: `\(name)`."
@@ -452,7 +453,7 @@ struct HTMLVisitor: MarkupVisitor {
             logger.warning(
                 "\(errors)",
                 metadata: [
-                    "name": .string(blockName),
+                    "name": .string(blockName)
                 ]
             )
             return ""
@@ -468,7 +469,7 @@ struct HTMLVisitor: MarkupVisitor {
                     logger.warning(
                         "Parameter `\(p.label)` for `\(block.name)` is required.",
                         metadata: [
-                            "name": .string(blockName),
+                            "name": .string(blockName)
                         ]
                     )
                 }
@@ -491,7 +492,7 @@ struct HTMLVisitor: MarkupVisitor {
                 logger.warning(
                     "Block directive `\(block.name)` requires parent block `\(parent)`",
                     metadata: [
-                        "name": .string(blockName),
+                        "name": .string(blockName)
                     ]
                 )
                 return ""

--- a/Sources/toucan-watch/Entrypoint.swift
+++ b/Sources/toucan-watch/Entrypoint.swift
@@ -11,6 +11,7 @@ import Logging
 import SwiftCommand
 import ToucanCore
 
+
 extension Logger.Level: @retroactive ExpressibleByArgument {}
 
 /// The main entry point for the command-line tool.
@@ -30,6 +31,9 @@ struct Entrypoint: AsyncParsableCommand {
 
     @Argument(help: "The input directory (default: current working directory).")
     var input: String = "."
+    
+    @Argument(help: "The directories to ignore.")
+    var ignore: String = "dist"
 
     @Option(
         name: .shortAndLong,
@@ -59,8 +63,18 @@ struct Entrypoint: AsyncParsableCommand {
     func run() async throws {
         let logger = Logger.subsystem("watch")
 
+        //
+        // NOTE: To test this feature
+        //
+        // 1. Make sure Toucan is installed somwehere.
+        // 2. Edit scheme in Xcode or use `setenv`, e.g.:
+        //     `setenv("PATH", "/usr/local/bin", 1)`
+        // 3. Set a `PATH` environment variable:
+        //      `PATH=/usr/local/bin`
+        //
         let currentToucanCommand = Command.findInPath(withName: "toucan")
         let toucanCommandUrl = currentToucanCommand?.executablePath.string
+        
         guard let toucan = toucanCommandUrl,
             FileManager.default.isExecutableFile(atPath: toucan)
         else {
@@ -89,7 +103,7 @@ struct Entrypoint: AsyncParsableCommand {
 
         let monitor = try FileMonitor(directory: inputURL)
         try monitor.start()
-        for await _ in monitor.stream {
+        for await event in monitor.stream {
             let now = Date()
             let last = lastGenerationTime
             let diff = abs(last.timeIntervalSince(now))
@@ -98,6 +112,13 @@ struct Entrypoint: AsyncParsableCommand {
                 logger.trace("Skipping generation due to treshold...")
                 continue
             }
+            #warning("TODO, also pakcage swift.")
+            print("---------------------")
+            print(event)
+            print(event.url.path())
+            print("---------------------")
+
+            
             lastGenerationTime = now
             logger.info("Generating site...")
 
@@ -114,5 +135,19 @@ struct Entrypoint: AsyncParsableCommand {
         let home = FileManager.default.homeDirectoryForCurrentUser.path
         let replaced = path.replacingOccurrences(of: "~", with: home)
         return .init(fileURLWithPath: replaced).standardized
+    }
+}
+
+fileprivate extension FileChange {
+
+    var url: URL {
+        switch self {
+        case let .added(file):
+            return file
+        case let .deleted(file):
+            return file
+        case let .changed(file):
+            return file
+        }
     }
 }

--- a/Sources/toucan-watch/Entrypoint.swift
+++ b/Sources/toucan-watch/Entrypoint.swift
@@ -32,7 +32,10 @@ struct Entrypoint: AsyncParsableCommand {
     @Argument(help: "The input directory (default: current working directory).")
     var input: String = "."
     
-    @Argument(help: "The directories to ignore.")
+    @Option(
+        name: .shortAndLong,
+        help: "The directory to ignore, relative to the working directory (default: dist)."
+    )
     var ignore: String = "dist"
 
     @Option(
@@ -43,7 +46,7 @@ struct Entrypoint: AsyncParsableCommand {
 
     @Option(
         name: .shortAndLong,
-        help: "The treshold to watch for changes in seconds."
+        help: "The treshold to watch for changes in seconds (default: 3)."
     )
     var seconds: Int = 3
 
@@ -63,6 +66,18 @@ struct Entrypoint: AsyncParsableCommand {
     func run() async throws {
         let logger = Logger.subsystem("watch")
 
+        let metadata: Logger.Metadata = [
+            "input": .string(input),
+            "target": .string(target ?? "(default)"),
+            "ignore": .string(ignore),
+            "treshold": .string(String(seconds)),
+        ]
+
+        logger.info(
+            "👀 Watching Toucan site.",
+            metadata: metadata
+        )
+
         //
         // NOTE: To test this feature
         //
@@ -78,15 +93,16 @@ struct Entrypoint: AsyncParsableCommand {
         guard let toucan = toucanCommandUrl,
             FileManager.default.isExecutableFile(atPath: toucan)
         else {
-            logger.error("Toucan is not installed.")
+            logger.error(
+                "Toucan is not installed.",
+                metadata: metadata
+            )
             return
         }
 
-        logger.info("👀 Watching: `\(input)`.")
+        
 
         let inputURL = safeURL(for: input)
-
-        var lastGenerationTime = Date()
 
         let commandURL = URL(fileURLWithPath: toucan)
         let command = Command(
@@ -97,35 +113,40 @@ struct Entrypoint: AsyncParsableCommand {
         let generate = try await command.output.stdout
 
         if !generate.isEmpty {
-            logger.debug(.init(stringLiteral: generate))
+            logger.debug(
+                .init(stringLiteral: generate),
+                metadata: metadata
+            )
             return
         }
+        
+        let ignoreURL = inputURL.appendingPathIfPresent(ignore)
 
         let monitor = try FileMonitor(directory: inputURL)
         try monitor.start()
-        for await event in monitor.stream {
-            let now = Date()
-            let last = lastGenerationTime
-            let diff = abs(last.timeIntervalSince(now))
+        for await event in monitor.stream.debounce(for: .seconds(seconds)) {
 
-            guard diff > Double(seconds) else {  // 3 sec treshold
-                logger.trace("Skipping generation due to treshold...")
+            let eventPath = event.url.path()
+            guard !eventPath.hasPrefix(ignoreURL.path()) else {
+                logger.trace(
+                    "Skipping generation due to ignore path.",
+                    metadata: metadata
+                )
                 continue
             }
-            #warning("TODO, also pakcage swift.")
-            print("---------------------")
-            print(event)
-            print(event.url.path())
-            print("---------------------")
 
-            
-            lastGenerationTime = now
-            logger.info("Generating site...")
+            logger.info(
+                "Generating site.",
+                metadata: metadata
+            )
 
             let generate = try await command.output.stdout
 
             if !generate.isEmpty {
-                logger.debug(.init(stringLiteral: generate))
+                logger.debug(
+                    .init(stringLiteral: generate),
+                    metadata: metadata
+                )
                 return
             }
         }
@@ -135,19 +156,5 @@ struct Entrypoint: AsyncParsableCommand {
         let home = FileManager.default.homeDirectoryForCurrentUser.path
         let replaced = path.replacingOccurrences(of: "~", with: home)
         return .init(fileURLWithPath: replaced).standardized
-    }
-}
-
-fileprivate extension FileChange {
-
-    var url: URL {
-        switch self {
-        case let .added(file):
-            return file
-        case let .deleted(file):
-            return file
-        case let .changed(file):
-            return file
-        }
     }
 }

--- a/Sources/toucan-watch/Entrypoint.swift
+++ b/Sources/toucan-watch/Entrypoint.swift
@@ -11,7 +11,6 @@ import Logging
 import SwiftCommand
 import ToucanCore
 
-
 extension Logger.Level: @retroactive ExpressibleByArgument {}
 
 /// The main entry point for the command-line tool.
@@ -31,10 +30,11 @@ struct Entrypoint: AsyncParsableCommand {
 
     @Argument(help: "The input directory (default: current working directory).")
     var input: String = "."
-    
+
     @Option(
         name: .shortAndLong,
-        help: "The directory to ignore, relative to the working directory (default: dist)."
+        help:
+            "The directory to ignore, relative to the working directory (default: dist)."
     )
     var ignore: String = "dist"
 
@@ -89,7 +89,7 @@ struct Entrypoint: AsyncParsableCommand {
         //
         let currentToucanCommand = Command.findInPath(withName: "toucan")
         let toucanCommandUrl = currentToucanCommand?.executablePath.string
-        
+
         guard let toucan = toucanCommandUrl,
             FileManager.default.isExecutableFile(atPath: toucan)
         else {
@@ -99,8 +99,6 @@ struct Entrypoint: AsyncParsableCommand {
             )
             return
         }
-
-        
 
         let inputURL = safeURL(for: input)
 
@@ -119,7 +117,7 @@ struct Entrypoint: AsyncParsableCommand {
             )
             return
         }
-        
+
         let ignoreURL = inputURL.appendingPathIfPresent(ignore)
 
         let monitor = try FileMonitor(directory: inputURL)


### PR DESCRIPTION
- New [FileMonitor](https://github.com/toucansites/FileMonitor) repo as a dependency to fix clone event & add Sendable conformance
- Use debounce for the generator event sequence (fixes timing issues)
- Add new `ignore` flag to the watch command to skip the `dist` directory by default.
