### PR TITLE
Fix percent encoding issue for "upper-level" directories

### DIFF
--- a/Sources/ToucanSDK/Toucan.swift
+++ b/Sources/ToucanSDK/Toucan.swift
@@ -52,7 +52,7 @@ public struct Toucan {
 
     func absoluteURL(
         for path: String,
-        cwd: String? = nil
+        cwd url: URL? = nil
     ) -> URL {
         if path.hasPrefix("/") {
             return URL(filePath: path).standardized
@@ -60,8 +60,7 @@ public struct Toucan {
         if path.hasPrefix("~") {
             return resolveHomeURL(for: path).standardized
         }
-        let cwd = cwd ?? fileManager.currentDirectoryPath
-        let cwdURL = URL(filePath: cwd)
+        let cwdURL = url ?? URL(filePath: fileManager.currentDirectoryPath)
         if path == "." || path == "./" {
             return cwdURL.standardized
         }
@@ -156,17 +155,19 @@ public struct Toucan {
             for target in activeBuildTargets {
                 let sourceURL = absoluteURL(
                     for: target.input,
-                    cwd: workDirURL.path()
+                    cwd: workDirURL
                 )
                 let distURL = absoluteURL(
                     for: target.output,
-                    cwd: workDirURL.path()
+                    cwd: workDirURL
                 )
 
                 logger.debug(
                     "Building target.",
                     metadata: [
                         "name": .string(target.name),
+                        "input": .string(target.input),
+                        "output": .string(target.output),
                         "workDir": .string(workDirURL.path()),
                         "srcDir": .string(sourceURL.path()),
                         "distDir": .string(distURL.path()),

--- a/Tests/ToucanSDKTests/E2ETestSuite.swift
+++ b/Tests/ToucanSDKTests/E2ETestSuite.swift
@@ -17,6 +17,35 @@ import ToucanSource
 struct E2ETestSuite {
 
     @Test
+    func upperLevelDirectoryPathEncoding() throws {
+        let now = Date()
+
+        try FileManagerPlayground {
+            Directory(name: "Hello World") {
+                Mocks.E2E.src(now: now)
+            }
+        }
+        .test {
+            let upperDir = $1.appendingPathIfPresent("Hello World")
+            let workDir = upperDir.appendingPathIfPresent("src")
+
+            let toucan = Toucan()
+            // NOTE: no need to percent encode the input dir in this case
+            let inputDir = workDir.path(percentEncoded: false)
+            try toucan.generate(
+                workDir: inputDir,
+                now: now
+            )
+
+            let distURL = workDir.appendingPathIfPresent("dist")
+            let notFoundURL = distURL.appendingPathIfPresent("404.html")
+            let notFound = try String(contentsOf: notFoundURL, encoding: .utf8)
+
+            #expect(notFound.contains("Not found page contents"))
+        }
+    }
+
+    @Test
     func notFound() throws {
         let now = Date()
 

--- a/Tests/ToucanSDKTests/Mocks/Mocks+ContentTypes.swift
+++ b/Tests/ToucanSDKTests/Mocks/Mocks+ContentTypes.swift
@@ -185,7 +185,7 @@ extension Mocks.ContentTypes {
                     references: "author",
                     relationType: .many,
                     order: .init(
-                        key: "title",
+                        key: "name",
                         direction: .asc
                     )
                 ),

--- a/Tests/ToucanSDKTests/Mocks/Mocks+E2E.swift
+++ b/Tests/ToucanSDKTests/Mocks/Mocks+E2E.swift
@@ -11,6 +11,7 @@ import ToucanSDK
 import ToucanSource
 
 extension Mocks.E2E {
+
     static func types(
         postType: ContentType
     ) -> Directory {


### PR DESCRIPTION
- fixes #157 (double percent encoding issue)
- add test coverage with a special directory name