### PR TITLE
Fix toucan command options are not forwarded

### DIFF
--- a/Sources/ToucanSDK/Content/Content+Query.swift
+++ b/Sources/ToucanSDK/Content/Content+Query.swift
@@ -96,7 +96,7 @@ public extension [Content] {
             filteredContents.sort { a, b in
                 let propertyForOrderKey: (Content) -> AnyCodable? = { item in
                     guard let value = item.properties[order.key] else {
-                        logger.warning(
+                        logger.debug(
                             "Missing order property key: `\(order.key)`.",
                             metadata: [
                                 "slug": .string(item.slug.value),

--- a/Sources/ToucanSDK/Content/Content+Query.swift
+++ b/Sources/ToucanSDK/Content/Content+Query.swift
@@ -96,7 +96,7 @@ public extension [Content] {
             filteredContents.sort { a, b in
                 let propertyForOrderKey: (Content) -> AnyCodable? = { item in
                     guard let value = item.properties[order.key] else {
-                        logger.debug(
+                        logger.warning(
                             "Missing order property key: `\(order.key)`.",
                             metadata: [
                                 "slug": .string(item.slug.value),

--- a/Sources/toucan-generate/Entrypoint.swift
+++ b/Sources/toucan-generate/Entrypoint.swift
@@ -22,7 +22,7 @@ struct Entrypoint: AsyncParsableCommand {
             Toucan Generate Command
             """,
         discussion: """
-            A markdown-based Static Site Generator (SSG) written in Swift.
+            Generates static files for your website using the selected build target.
             """,
         version: GeneratorInfo.current.release.description
     )

--- a/Sources/toucan-init/Entrypoint.swift
+++ b/Sources/toucan-init/Entrypoint.swift
@@ -23,7 +23,7 @@ struct Entrypoint: AsyncParsableCommand {
             Toucan Init Command
             """,
         discussion: """
-            A markdown-based Static Site Generator (SSG) written in Swift.
+            Initializes a new Toucan project. Creates required folders and files in the specified directory.
             """,
         version: GeneratorInfo.current.release.description
     )

--- a/Sources/toucan-serve/Entrypoint.swift
+++ b/Sources/toucan-serve/Entrypoint.swift
@@ -30,14 +30,8 @@ struct Entrypoint: AsyncParsableCommand {
     @Argument(help: "The root directory (default: dist).")
     var root: String = "./dist"
 
-    @Option(
-        name: [
-            .customLong("host"),
-            .long,
-        ],
-        help: "Host to bind to"
-    )
-    var hostname: String = "127.0.0.1"
+    @Option(name: .shortAndLong)
+    var address: String = "0.0.0.0"
 
     @Option(name: .shortAndLong)
     var port: Int = 3000
@@ -65,7 +59,7 @@ struct Entrypoint: AsyncParsableCommand {
         let app = Application(
             router: router,
             configuration: .init(
-                address: .hostname(hostname, port: port),
+                address: .hostname(address, port: port),
                 serverName: "toucan-server"
             ),
             logger: logger

--- a/Sources/toucan-serve/Entrypoint.swift
+++ b/Sources/toucan-serve/Entrypoint.swift
@@ -22,7 +22,7 @@ struct Entrypoint: AsyncParsableCommand {
             Toucan Serve Command
             """,
         discussion: """
-            Serves a directory over a local web-server.
+            Starts a local web server to serve a specified directory.
             """,
         version: GeneratorInfo.current.release.description
     )
@@ -30,7 +30,13 @@ struct Entrypoint: AsyncParsableCommand {
     @Argument(help: "The root directory (default: dist).")
     var root: String = "./dist"
 
-    @Option(name: .shortAndLong)
+    @Option(
+        name: [
+            .customLong("host"),
+            .long,
+        ],
+        help: "Host to bind to"
+    )
     var hostname: String = "127.0.0.1"
 
     @Option(name: .shortAndLong)

--- a/Sources/toucan-watch/Entrypoint.swift
+++ b/Sources/toucan-watch/Entrypoint.swift
@@ -23,7 +23,7 @@ struct Entrypoint: AsyncParsableCommand {
             Toucan Watch Command
             """,
         discussion: """
-            A markdown-based Static Site Generator (SSG) written in Swift.
+            Watches your project directory for changes and automatically rebuilds output files when content is updated.
             """,
         version: GeneratorInfo.current.release.description
     )

--- a/Sources/toucan/Entrypoint.swift
+++ b/Sources/toucan/Entrypoint.swift
@@ -44,7 +44,9 @@ struct Entrypoint: AsyncParsableCommand {
             let path = args.popFirst(),
             let subcommand = args.popFirst()
         else {
-            fatalError("Missing arguments, at least one subcommand is required.")
+            fatalError(
+                "Missing arguments, at least one subcommand is required."
+            )
         }
 
         let base = URL(fileURLWithPath: path).lastPathComponent
@@ -58,7 +60,7 @@ struct Entrypoint: AsyncParsableCommand {
             displayVersion()
             return
         }
-        
+
         guard let exe = Command.findInPath(withName: toucanCmd) else {
             fatalError("Subcommand not found: `\(toucanCmd)`.")
         }
@@ -86,7 +88,7 @@ struct Entrypoint: AsyncParsableCommand {
 
         try subprocess.wait()
     }
-    
+
     private func displayVersion() {
         print(Self.configuration.version)
     }
@@ -95,23 +97,23 @@ struct Entrypoint: AsyncParsableCommand {
         print(
             """
             OVERVIEW: \(Self.configuration.abstract)
-            
+
             \(Self.configuration.discussion)
-            
+
             USAGE:
             toucan <subcommand>
-            
+
             SUBCOMMANDS:
             init            Initializes a new Toucan project
             generate        Build static files using configured targets
             watch           Watch for changes and auto-regenerate output
             serve           Start a local web server to preview the site
-            
+
             OPTIONS:
             --version       Show the version.
             -h, --help      Show help information.
             """
         )
     }
-    
+
 }

--- a/Sources/toucan/Entrypoint.swift
+++ b/Sources/toucan/Entrypoint.swift
@@ -7,8 +7,9 @@
 import ArgumentParser
 import Dispatch
 import Foundation
-import SwiftCommand
 import ToucanCore
+import SystemPackage
+import SwiftCommand
 
 extension Array {
     mutating func popFirst() -> Element? {
@@ -28,7 +29,8 @@ struct Entrypoint: AsyncParsableCommand {
         discussion: """
             A markdown-based Static Site Generator (SSG) written in Swift.
             """,
-        version: GeneratorInfo.current.version
+        version: GeneratorInfo.current.version,
+        helpNames: []  // disables auto -h/--help
     )
 
     @Argument(parsing: .allUnrecognized)
@@ -36,7 +38,6 @@ struct Entrypoint: AsyncParsableCommand {
 
     func run() async throws {
         var args = CommandLine.arguments
-
         guard
             args.count > 1,
             let path = args.popFirst(),
@@ -45,14 +46,31 @@ struct Entrypoint: AsyncParsableCommand {
             fatalError("argument error")
         }
 
+        if subcommand.isEmpty || subcommand == "--help" || subcommand == "-h" {
+            printHelp()
+            return
+        }
+
         let base = URL(fileURLWithPath: path).lastPathComponent
         let toucanCmd = base + "-" + subcommand
 
-        guard let exe = Command.findInPath(withName: toucanCmd) else {
-            fatalError("Command not found (\(toucanCmd)).")
+        let executableDir = URL(fileURLWithPath: path)
+            .deletingLastPathComponent()
+        let siblingBinary = executableDir.appendingPathComponent(toucanCmd).path
+
+        let exe =
+            FileManager.default.isExecutableFile(atPath: siblingBinary)
+            ? Command(executablePath: FilePath(siblingBinary))
+            : Command.findInPath(withName: toucanCmd)
+
+        guard let resolvedExe = exe else {
+            fputs("error: Unknown subcommand '\(subcommand)'\n\n", stderr)
+            printHelp()
+            return
         }
+
         let cmd =
-            exe
+            resolvedExe
             .addArguments(args)
             .setStdin(.pipe(closeImplicitly: false))
             .setStdout(.inherit)
@@ -74,5 +92,30 @@ struct Entrypoint: AsyncParsableCommand {
         signalSource.resume()
 
         try subprocess.wait()
+    }
+
+    private func printHelp() {
+        print(
+            """
+            OVERVIEW: Toucan Command
+
+            A markdown-based Static Site Generator (SSG) written in Swift.
+
+            USAGE:
+            toucan <subcommand> ...
+            or
+            toucan-<subcommand> ...
+
+            SUBCOMMANDS:
+            init            Initializes a new Toucan project
+            generate        Build static files using configured targets
+            watch           Watch for changes and auto-regenerate output
+            serve           Start a local web server to preview the site
+
+            OPTIONS:
+            --version       Show the version.
+            -h, --help      Show help information.
+            """
+        )
     }
 }

--- a/Sources/toucan/Entrypoint.swift
+++ b/Sources/toucan/Entrypoint.swift
@@ -7,9 +7,8 @@
 import ArgumentParser
 import Dispatch
 import Foundation
-import ToucanCore
-import SystemPackage
 import SwiftCommand
+import ToucanCore
 
 extension Array {
     mutating func popFirst() -> Element? {
@@ -20,6 +19,7 @@ extension Array {
 /// The main entry point for the command-line tool.
 @main
 struct Entrypoint: AsyncParsableCommand {
+
     /// Configuration for the command-line tool.
     static let configuration = CommandConfiguration(
         commandName: "toucan",
@@ -30,7 +30,7 @@ struct Entrypoint: AsyncParsableCommand {
             A markdown-based Static Site Generator (SSG) written in Swift.
             """,
         version: GeneratorInfo.current.version,
-        helpNames: []  // disables auto -h/--help
+        helpNames: []
     )
 
     @Argument(parsing: .allUnrecognized)
@@ -38,39 +38,32 @@ struct Entrypoint: AsyncParsableCommand {
 
     func run() async throws {
         var args = CommandLine.arguments
+
         guard
             args.count > 1,
             let path = args.popFirst(),
             let subcommand = args.popFirst()
         else {
-            fatalError("argument error")
-        }
-
-        if subcommand.isEmpty || subcommand == "--help" || subcommand == "-h" {
-            printHelp()
-            return
+            fatalError("Missing arguments, at least one subcommand is required.")
         }
 
         let base = URL(fileURLWithPath: path).lastPathComponent
         let toucanCmd = base + "-" + subcommand
 
-        let executableDir = URL(fileURLWithPath: path)
-            .deletingLastPathComponent()
-        let siblingBinary = executableDir.appendingPathComponent(toucanCmd).path
-
-        let exe =
-            FileManager.default.isExecutableFile(atPath: siblingBinary)
-            ? Command(executablePath: FilePath(siblingBinary))
-            : Command.findInPath(withName: toucanCmd)
-
-        guard let resolvedExe = exe else {
-            fputs("error: Unknown subcommand '\(subcommand)'\n\n", stderr)
-            printHelp()
+        if subcommand.isEmpty || subcommand == "--help" || subcommand == "-h" {
+            displayHelp()
             return
         }
-
+        if subcommand == "--version" {
+            displayVersion()
+            return
+        }
+        
+        guard let exe = Command.findInPath(withName: toucanCmd) else {
+            fatalError("Subcommand not found: `\(toucanCmd)`.")
+        }
         let cmd =
-            resolvedExe
+            exe
             .addArguments(args)
             .setStdin(.pipe(closeImplicitly: false))
             .setStdout(.inherit)
@@ -93,29 +86,32 @@ struct Entrypoint: AsyncParsableCommand {
 
         try subprocess.wait()
     }
+    
+    private func displayVersion() {
+        print(Self.configuration.version)
+    }
 
-    private func printHelp() {
+    private func displayHelp() {
         print(
             """
-            OVERVIEW: Toucan Command
-
-            A markdown-based Static Site Generator (SSG) written in Swift.
-
+            OVERVIEW: \(Self.configuration.abstract)
+            
+            \(Self.configuration.discussion)
+            
             USAGE:
-            toucan <subcommand> ...
-            or
-            toucan-<subcommand> ...
-
+            toucan <subcommand>
+            
             SUBCOMMANDS:
             init            Initializes a new Toucan project
             generate        Build static files using configured targets
             watch           Watch for changes and auto-regenerate output
             serve           Start a local web server to preview the site
-
+            
             OPTIONS:
             --version       Show the version.
             -h, --help      Show help information.
             """
         )
     }
+    
 }


### PR DESCRIPTION
- Improve `toucan` command behavior #161 : 
   • Replace `fatalError` with `exit(1)` and `printHelp()` when the subcommand binary is not found, to avoid crashing and improve CLI UX. 
  • Show custom help when no subcommand is provided, `-h`/`--help` is used, or an unknown command is entered. 
  • Disable default help flag interception (`helpNames: []`) to allow manual passthrough of help flags to subcommands.

- Support both `--host` and `--hostname` flags in `toucan-serve` to avoid overlap with the `-h` help flag.

- New `discussion` is added for all subcommands to clarify invocation style.
- change log level from `warning` to `debug`  #159 